### PR TITLE
Single Telegram client: shared, rate-limited queue + roll-over

### DIFF
--- a/client-redmine/pom.xml
+++ b/client-redmine/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.payneteasy</groupId>
+            <artifactId>telegram-bot-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.nashorn</groupId>
             <artifactId>nashorn-core</artifactId>
             <scope>runtime</scope>

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
@@ -40,6 +40,10 @@ public class DiffServiceImpl implements DiffService {
         this(aRedmine, new RemoteGitlabServiceImpl(aConfig), new RemoteTelegramServiceImpl(aConfig), aConfig.url());
     }
 
+    public DiffServiceImpl(IRemoteRedmineService aRedmine, IRemoteTelegramService aTelegram, IRedmineRemoteConfig aConfig) {
+        this(aRedmine, new RemoteGitlabServiceImpl(aConfig), aTelegram, aConfig.url());
+    }
+
     public DiffServiceImpl(IRemoteRedmineService aRedmine, IRemoteGitlabService aGitlab,
                            IRemoteTelegramService aTelegram, String aRedmineUrl) {
         this.redmine = aRedmine;

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
@@ -7,6 +7,7 @@ import io.pne.deploy.client.redmine.process.IRedmineIssuesProcessService;
 import io.pne.deploy.client.redmine.process.ProcessRedmineIssueResult;
 import io.pne.deploy.client.redmine.process.data_model.DiffTask;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
+import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
 import io.pne.deploy.server.api.IDeployService;
@@ -32,10 +33,10 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
     private final DiffService diffService;
 
 
-    public RedmineIssuesProcessServiceImpl(IRemoteRedmineService redmine, IDeployService deployService, IRedmineRemoteConfig aConfig) {
+    public RedmineIssuesProcessServiceImpl(IRemoteRedmineService redmine, IDeployService deployService, IRedmineRemoteConfig aConfig, IRemoteTelegramService telegram) {
         this.redmine = redmine;
         this.deployService = deployService;
-        this.diffService = new DiffServiceImpl(redmine, aConfig);
+        this.diffService = new DiffServiceImpl(redmine, telegram, aConfig);
         issueValidationScript = aConfig.issueValidationScript();
     }
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
@@ -1,34 +1,24 @@
 package io.pne.deploy.client.redmine.remote.impl;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.payneteasy.http.client.api.*;
-import com.payneteasy.http.client.impl.HttpClientImpl;
+import com.payneteasy.telegram.bot.client.ITelegramService;
+import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
+import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
+import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
+import com.payneteasy.telegram.bot.client.model.ParseMode;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
-    private final IHttpClient client;
-    private final Gson gson;
-    private final HttpRequestParameters requestParameters = HttpRequestParameters.builder().timeouts(new HttpTimeouts(20_000, 20_000)).build();
-    private static final String CONTENT_TYPE = "Content-Type";
-    private static final String APPLICATION_JSON = "application/json";
-    private final long telegramChatId;
-    private final boolean telegramEnabled;
-    private final String telegramUrl;
+
+    private final boolean          telegramEnabled;
+    private final long             telegramChatId;
+    private final ITelegramService telegram;
 
     public RemoteTelegramServiceImpl(IRedmineRemoteConfig aConfig) {
         telegramEnabled = aConfig.isTelegramEnabled();
-        telegramChatId = aConfig.getTelegramChatId();
-        telegramUrl = "https://api.telegram.org/bot" + aConfig.getTelegramToken();
-        client = new HttpClientImpl();
-        gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+        telegramChatId  = aConfig.getTelegramChatId();
+        telegram        = new TelegramServiceImpl(new TelegramHttpClientImpl(aConfig.getTelegramToken()));
     }
 
     @Override
@@ -36,7 +26,7 @@ public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
         if (!telegramEnabled) {
             return;
         }
-        for (String message: messages) {
+        for (String message : messages) {
             sendMessage(message);
         }
     }
@@ -46,27 +36,10 @@ public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
         if (!telegramEnabled) {
             return;
         }
-        Map<String, Object> body = new HashMap<>();
-        body.put("chat_id", telegramChatId);
-        body.put("text", message);
-        body.put("parse_mode", "html");
-        String requestBody = gson.toJson(body);
-        String requestUrl = telegramUrl + "/sendMessage";
-        HttpRequest request = HttpRequest.builder()
-                .url(requestUrl)
-                .headers(new HttpHeaders(Collections.singletonList(new HttpHeader(CONTENT_TYPE, APPLICATION_JSON))))
-                .method(HttpMethod.POST)
-                .body(requestBody.getBytes(UTF_8))
-                .build();
-        HttpResponse response;
-        try {
-            response = client.send(request, requestParameters);
-        } catch (Exception e) {
-            throw new IllegalStateException("Cannot send request to telegram", e);
-        }
-        if (response.getStatusCode() != 200) {
-            throw new IllegalStateException(
-                    "Unsuccessful sending message to Telegram. StatusCode=" + response.getStatusCode() + ", Message=" + message);
-        }
+        telegram.sendMessage(TelegramMessageRequest.builder()
+                .chatId(telegramChatId)
+                .text(message)
+                .parseMode(ParseMode.HTML)
+                .build());
     }
 }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
@@ -12,9 +12,13 @@ public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
     private final TelegramClient telegram;
 
     public RemoteTelegramServiceImpl(IRedmineRemoteConfig aConfig) {
+        this(new TelegramClient(aConfig.getTelegramToken()), aConfig);
+    }
+
+    public RemoteTelegramServiceImpl(TelegramClient aTelegram, IRedmineRemoteConfig aConfig) {
         telegramEnabled = aConfig.isTelegramEnabled();
         telegramChatId  = aConfig.getTelegramChatId();
-        telegram        = new TelegramClient(aConfig.getTelegramToken());
+        telegram        = aTelegram;
     }
 
     @Override

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
@@ -1,9 +1,5 @@
 package io.pne.deploy.client.redmine.remote.impl;
 
-import com.payneteasy.telegram.bot.client.ITelegramService;
-import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
-import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
-import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
 import com.payneteasy.telegram.bot.client.model.ParseMode;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 
@@ -11,14 +7,14 @@ import java.util.List;
 
 public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
 
-    private final boolean          telegramEnabled;
-    private final long             telegramChatId;
-    private final ITelegramService telegram;
+    private final boolean        telegramEnabled;
+    private final long           telegramChatId;
+    private final TelegramClient telegram;
 
     public RemoteTelegramServiceImpl(IRedmineRemoteConfig aConfig) {
         telegramEnabled = aConfig.isTelegramEnabled();
         telegramChatId  = aConfig.getTelegramChatId();
-        telegram        = new TelegramServiceImpl(new TelegramHttpClientImpl(aConfig.getTelegramToken()));
+        telegram        = new TelegramClient(aConfig.getTelegramToken());
     }
 
     @Override
@@ -36,10 +32,6 @@ public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
         if (!telegramEnabled) {
             return;
         }
-        telegram.sendMessage(TelegramMessageRequest.builder()
-                .chatId(telegramChatId)
-                .text(message)
-                .parseMode(ParseMode.HTML)
-                .build());
+        telegram.sendMessage(telegramChatId, message, ParseMode.HTML);
     }
 }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -1,0 +1,42 @@
+package io.pne.deploy.client.redmine.remote.impl;
+
+import com.payneteasy.telegram.bot.client.ITelegramService;
+import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
+import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
+import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
+import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
+import com.payneteasy.telegram.bot.client.model.ParseMode;
+
+/**
+ * Единственная точка работы с библиотекой telegram-bot-client в проекте: используется и
+ * client-redmine (diff-уведомления, HTML), и server-vertx (live-статус, плоский текст).
+ * {@code parseMode} может быть null (плоский текст).
+ */
+public class TelegramClient {
+
+    private final ITelegramService telegram;
+
+    public TelegramClient(String aToken) {
+        this.telegram = new TelegramServiceImpl(new TelegramHttpClientImpl(aToken));
+    }
+
+    /** @return message_id отправленного сообщения */
+    public long sendMessage(long aChatId, String aText, ParseMode aParseMode) {
+        return telegram.sendMessage(TelegramMessageRequest.builder()
+                        .chatId(aChatId)
+                        .text(aText)
+                        .parseMode(aParseMode)
+                        .build())
+                .getResult()
+                .getMessageId();
+    }
+
+    public void editMessage(long aChatId, long aMessageId, String aText, ParseMode aParseMode) {
+        telegram.editMessageText(EditMessageTextRequest.builder()
+                .chatId(aChatId)
+                .messageId(aMessageId)
+                .text(aText)
+                .parseMode(aParseMode)
+                .build());
+    }
+}

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -1,42 +1,177 @@
 package io.pne.deploy.client.redmine.remote.impl;
 
 import com.payneteasy.telegram.bot.client.ITelegramService;
+import com.payneteasy.telegram.bot.client.TelegramCommandException;
 import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
 import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
 import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
 import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
 import com.payneteasy.telegram.bot.client.model.ParseMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
 
 /**
- * Единственная точка работы с библиотекой telegram-bot-client в проекте: используется и
- * client-redmine (diff-уведомления, HTML), и server-vertx (live-статус, плоский текст).
- * {@code parseMode} может быть null (плоский текст).
+ * Единственная точка работы с telegram-bot-client. Все вызовы идут через один поток-воркер с
+ * ограничением темпа (не чаще одного обращения в {@code minIntervalMs}) и повтором на 429 по
+ * {@code retry_after}. Частые правки одного и того же сообщения коалесятся до последнего текста.
  */
 public class TelegramClient {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TelegramClient.class);
+
+    private static final long DEFAULT_MIN_INTERVAL_MS = 1100;
+    private static final int  MAX_RETRIES             = 5;
+
     private final ITelegramService telegram;
+    private final long             minIntervalMs;
+
+    private final BlockingQueue<Runnable> queue        = new LinkedBlockingQueue<>();
+    private final Map<Long, PendingEdit>  pendingEdits = new HashMap<>(); // guarded by itself
+
+    private volatile long lastCallAt = 0;
 
     public TelegramClient(String aToken) {
-        this.telegram = new TelegramServiceImpl(new TelegramHttpClientImpl(aToken));
+        this(new TelegramServiceImpl(new TelegramHttpClientImpl(aToken)), DEFAULT_MIN_INTERVAL_MS);
     }
 
-    /** @return message_id отправленного сообщения */
+    public TelegramClient(ITelegramService aTelegram, long aMinIntervalMs) {
+        this.telegram      = aTelegram;
+        this.minIntervalMs = aMinIntervalMs;
+        Thread worker = new Thread(this::runWorker, "telegram-sender");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    /** Блокирующая отправка нового сообщения; возвращает message_id. */
     public long sendMessage(long aChatId, String aText, ParseMode aParseMode) {
-        return telegram.sendMessage(TelegramMessageRequest.builder()
-                        .chatId(aChatId)
-                        .text(aText)
-                        .parseMode(aParseMode)
-                        .build())
-                .getResult()
-                .getMessageId();
+        CompletableFuture<Long> future = new CompletableFuture<>();
+        queue.add(() -> {
+            try {
+                future.complete(callWithRetry(() -> telegram.sendMessage(TelegramMessageRequest.builder()
+                                .chatId(aChatId)
+                                .text(aText)
+                                .parseMode(aParseMode)
+                                .build())
+                        .getResult()
+                        .getMessageId()));
+            } catch (RuntimeException e) {
+                future.completeExceptionally(e);
+            }
+        });
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while sending Telegram message", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new IllegalStateException(cause);
+        }
     }
 
+    /** Асинхронная правка с коалесингом: сохраняем последний текст и планируем один вызов на messageId. */
     public void editMessage(long aChatId, long aMessageId, String aText, ParseMode aParseMode) {
-        telegram.editMessageText(EditMessageTextRequest.builder()
-                .chatId(aChatId)
-                .messageId(aMessageId)
-                .text(aText)
-                .parseMode(aParseMode)
-                .build());
+        boolean schedule;
+        synchronized (pendingEdits) {
+            schedule = !pendingEdits.containsKey(aMessageId);
+            pendingEdits.put(aMessageId, new PendingEdit(aChatId, aText, aParseMode));
+        }
+        if (schedule) {
+            queue.add(() -> flushEdit(aMessageId));
+        }
+    }
+
+    private void flushEdit(long aMessageId) {
+        PendingEdit edit;
+        synchronized (pendingEdits) {
+            edit = pendingEdits.remove(aMessageId);
+        }
+        if (edit == null) {
+            return;
+        }
+        callWithRetry(() -> {
+            telegram.editMessageText(EditMessageTextRequest.builder()
+                    .chatId(edit.chatId)
+                    .messageId(aMessageId)
+                    .text(edit.text)
+                    .parseMode(edit.parseMode)
+                    .build());
+            return null;
+        });
+    }
+
+    private void runWorker() {
+        while (!Thread.currentThread().isInterrupted()) {
+            Runnable job;
+            try {
+                job = queue.take();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+            try {
+                job.run();
+            } catch (Exception e) {
+                LOG.error("Telegram job failed", e);
+            }
+        }
+    }
+
+    private <T> T callWithRetry(Supplier<T> aCall) {
+        for (int attempt = 1; ; attempt++) {
+            awaitRateLimit();
+            try {
+                return aCall.get();
+            } catch (TelegramCommandException e) {
+                Integer code = e.getErrorCode();
+                if (code != null && code == 429 && attempt <= MAX_RETRIES) {
+                    long waitMs = e.getRetryAfter() != null ? e.getRetryAfter() * 1000L : minIntervalMs;
+                    LOG.warn("Telegram 429, retry #{} after {}ms", attempt, waitMs);
+                    sleep(waitMs);
+                    continue;
+                }
+                throw e;
+            } finally {
+                lastCallAt = System.currentTimeMillis();
+            }
+        }
+    }
+
+    private void awaitRateLimit() {
+        sleep(lastCallAt + minIntervalMs - System.currentTimeMillis());
+    }
+
+    private static void sleep(long aMs) {
+        if (aMs <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(aMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static final class PendingEdit {
+        final long      chatId;
+        final String    text;
+        final ParseMode parseMode;
+
+        PendingEdit(long aChatId, String aText, ParseMode aParseMode) {
+            this.chatId    = aChatId;
+            this.text      = aText;
+            this.parseMode = aParseMode;
+        }
     }
 }

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
@@ -1,0 +1,84 @@
+package io.pne.deploy.client.redmine.remote.impl;
+
+import com.payneteasy.telegram.bot.client.ITelegramService;
+import com.payneteasy.telegram.bot.client.TelegramCommandException;
+import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
+import com.payneteasy.telegram.bot.client.model.Message;
+import com.payneteasy.telegram.bot.client.model.ParseMode;
+import com.payneteasy.telegram.bot.client.model.TelegramMessage;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TelegramClientTest {
+
+    private final ITelegramService service = mock(ITelegramService.class);
+    private final TelegramClient   client  = new TelegramClient(service, 0L); // no pacing delay in tests
+
+    @Test
+    public void sendMessageReturnsMessageId() {
+        TelegramMessage sent = message(555L);
+        when(service.sendMessage(any())).thenReturn(sent);
+        assertEquals(555L, client.sendMessage(1L, "hi", ParseMode.HTML));
+    }
+
+    @Test
+    public void retriesOnTooManyRequests() {
+        TelegramMessage sent = message(7L);
+        when(service.sendMessage(any()))
+                .thenThrow(new TelegramCommandException("Too Many Requests", "1", 429, 0))
+                .thenReturn(sent);
+
+        assertEquals(7L, client.sendMessage(1L, "hi", null));
+        verify(service, times(2)).sendMessage(any());
+    }
+
+    @Test
+    public void coalescesRapidEditsOfSameMessage() throws Exception {
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicInteger  calls   = new AtomicInteger();
+        when(service.editMessageText(any())).thenAnswer(invocation -> {
+            if (calls.getAndIncrement() == 0) {
+                entered.countDown();
+                release.await(); // hold the worker inside the first edit
+            }
+            return null;
+        });
+
+        client.editMessage(1L, 10L, "t0", null);       // schedules the first flush
+        assertTrue(entered.await(2, SECONDS));           // worker is now blocked in the first editMessageText
+
+        for (int i = 1; i <= 20; i++) {
+            client.editMessage(1L, 10L, "t" + i, null);  // coalesce into a single follow-up flush
+        }
+        release.countDown();
+
+        // exactly 2 calls: the in-flight one + one coalesced carrying the latest text
+        ArgumentCaptor<EditMessageTextRequest> captor = ArgumentCaptor.forClass(EditMessageTextRequest.class);
+        verify(service, timeout(2000).times(2)).editMessageText(captor.capture());
+        verify(service, after(300).times(2)).editMessageText(any());
+        assertEquals("t20", captor.getAllValues().get(1).getText());
+    }
+
+    private static TelegramMessage message(long aId) {
+        Message message = mock(Message.class);
+        when(message.getMessageId()).thenReturn(aId);
+        TelegramMessage telegramMessage = mock(TelegramMessage.class);
+        when(telegramMessage.getResult()).thenReturn(message);
+        return telegramMessage;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
             <dependency>
                 <groupId>com.payneteasy</groupId>
                 <artifactId>telegram-bot-client</artifactId>
-                <version>1.0-9</version>
+                <version>1.0-10</version>
             </dependency>
 
             <dependency>

--- a/server-vertx/pom.xml
+++ b/server-vertx/pom.xml
@@ -53,6 +53,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
         </dependency>

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -5,8 +5,11 @@ import com.google.gson.GsonBuilder;
 import com.payneteasy.startup.parameters.StartupParametersFactory;
 import io.pne.deploy.client.redmine.process.impl.RedmineIssuesProcessServiceImpl;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
+import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
 import io.pne.deploy.client.redmine.remote.impl.RemoteRedmine4_2_10ServiceImpl;
+import io.pne.deploy.client.redmine.remote.impl.RemoteTelegramServiceImpl;
+import io.pne.deploy.client.redmine.remote.impl.TelegramClient;
 import io.pne.deploy.server.IServerApplicationListener;
 import io.pne.deploy.server.api.IDeployService;
 import io.pne.deploy.server.api.ITaskExecutionListener;
@@ -88,11 +91,15 @@ public class VertxServerApplication {
         IRemoteRedmineService     redmine           = new RemoteRedmine4_2_10ServiceImpl(redmineConfig);
         IVertxServerConfiguration config            = StartupParametersFactory.getStartupParameters(IVertxServerConfiguration.class);
         StatusHttpHandler         statusHttpHandler = new StatusHttpHandler(agentConnections, pendingIssues);
-        ITaskExecutionListener    taskListener      = createTaskListener(statusHttpHandler, redmineConfig);
+        // Single Telegram client shared by both the live-status listener and the diff notifications,
+        // so all traffic goes through one rate-limited queue (one limit per chat).
+        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.getTelegramToken());
+        IRemoteTelegramService    diffTelegram      = new RemoteTelegramServiceImpl(telegramClient, redmineConfig);
+        ITaskExecutionListener    taskListener      = createTaskListener(statusHttpHandler, redmineConfig, telegramClient);
 
         deployService       = new DeployServiceImpl(new VertxAgentFinderServiceImpl(agentConnections, gson, response, taskListener), config.getAliasesDir(), taskListener);
 
-        RedmineIssuesProcessServiceImpl redmineIssuesProcessService = new RedmineIssuesProcessServiceImpl(redmine, deployService, redmineConfig);
+        RedmineIssuesProcessServiceImpl redmineIssuesProcessService = new RedmineIssuesProcessServiceImpl(redmine, deployService, redmineConfig, diffTelegram);
         VertxServerApplicationListener serverListener = new VertxServerApplicationListener(redmineIssuesProcessService, pendingIssues);
 
         this.vertx          = Vertx.vertx();
@@ -101,13 +108,13 @@ public class VertxServerApplication {
         this.serverListener = serverListener;
     }
 
-    private ITaskExecutionListener createTaskListener(Consumer<TaskStatus> aConsumer, IRedmineRemoteConfig aConfig) {
+    private ITaskExecutionListener createTaskListener(Consumer<TaskStatus> aConsumer, IRedmineRemoteConfig aConfig, TelegramClient aTelegramClient) {
 
         return new TaskExecutionListenerQueue(
                 new TaskExecutionListenerCompound(
                         new TaskExecutionListenerLogger(),
                         new TaskExecutionListenerStatus(aConsumer),
-                        aConfig.isTelegramEnabled() ? new TaskExecutionListenerTelegram(aConfig.getTelegramChatId(), aConfig.getTelegramToken()) : null
+                        aConfig.isTelegramEnabled() ? new TaskExecutionListenerTelegram(aConfig.getTelegramChatId(), aTelegramClient) : null
                 )
         );
     }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/TaskExecutionListenerTelegram.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/TaskExecutionListenerTelegram.java
@@ -15,10 +15,10 @@ public class TaskExecutionListenerTelegram implements ITaskExecutionListener {
     private final long                  chatId;
     private final TelegramMessagesStore store;
 
-    public TaskExecutionListenerTelegram(long aChatId, String aToken) {
+    public TaskExecutionListenerTelegram(long aChatId, TelegramClient aTelegram) {
         chatId   = aChatId;
-        telegram = new TelegramClient(aToken);
-        store    = new TelegramMessagesStore(telegram, aChatId);
+        telegram = aTelegram;
+        store    = new TelegramMessagesStore(aTelegram, aChatId);
     }
 
     @Override

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/TaskExecutionListenerTelegram.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/TaskExecutionListenerTelegram.java
@@ -1,13 +1,9 @@
 package io.pne.deploy.server.vertx.status;
 
-import com.payneteasy.telegram.bot.client.ITelegramService;
-import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
-import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
-import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
-import com.payneteasy.telegram.bot.client.model.TelegramMessage;
 import io.pne.deploy.agent.api.messages.RunAgentCommandLog;
 import io.pne.deploy.agent.api.messages.RunAgentCommandRequest;
 import io.pne.deploy.agent.api.messages.RunAgentCommandResponse;
+import io.pne.deploy.client.redmine.remote.impl.TelegramClient;
 import io.pne.deploy.server.api.ITaskExecutionListener;
 import io.pne.deploy.server.api.task.Task;
 import io.pne.deploy.server.api.task.TaskCommand;
@@ -15,36 +11,32 @@ import io.pne.deploy.server.vertx.status.telegram.TelegramMessagesStore;
 
 public class TaskExecutionListenerTelegram implements ITaskExecutionListener {
 
-    private final ITelegramService      telegramService;
+    private final TelegramClient        telegram;
     private final long                  chatId;
     private final TelegramMessagesStore store;
 
     public TaskExecutionListenerTelegram(long aChatId, String aToken) {
-        chatId = aChatId;
-        telegramService = new TelegramServiceImpl(
-                new TelegramHttpClientImpl(
-                        aToken
-                )
-        );
-        store = new TelegramMessagesStore(telegramService);
+        chatId   = aChatId;
+        telegram = new TelegramClient(aToken);
+        store    = new TelegramMessagesStore(telegram, aChatId);
     }
 
     @Override
     public void onTaskStart(Task aTask) {
-        String text = "\uD83D\uDEEB " + aTask.taskLine; // 🛫
-        TelegramMessage telegramMessage = sendMessage(text);
-        store.addTask(aTask, telegramMessage,  text);
+        String text = "🛫 " + aTask.taskLine; // 🛫
+        long messageId = sendMessage(text);
+        store.addTask(aTask, messageId, text);
     }
 
     @Override
     public void onTaskSuccess(Task aTask) {
-        sendMessage("\uD83D\uDC4C " + aTask.taskLine); // 👌
+        sendMessage("👌 " + aTask.taskLine); // 👌
         store.removeTask(aTask);
     }
 
     @Override
     public void onTaskError(Task aTask, Exception aException) {
-        sendMessage("\uD83D\uDD25 " + aTask.taskLine); // 🔥
+        sendMessage("🔥 " + aTask.taskLine); // 🔥
         store.removeTask(aTask);
     }
 
@@ -93,11 +85,7 @@ public class TaskExecutionListenerTelegram implements ITaskExecutionListener {
 
     }
 
-    private TelegramMessage sendMessage(String aMessage) {
-        return telegramService.sendMessage(TelegramMessageRequest.builder()
-                .chatId(chatId)
-                .text(aMessage)
-                .build());
+    private long sendMessage(String aMessage) {
+        return telegram.sendMessage(chatId, aMessage, null);
     }
 }
-

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessageHolder.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessageHolder.java
@@ -10,7 +10,6 @@ import static lombok.AccessLevel.PRIVATE;
 @Data
 @FieldDefaults(makeFinal = true, level = PRIVATE)
 public class TelegramMessageHolder {
-    long chatId;
-    long messageId;
+    long   messageId;
     String text;
 }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStore.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStore.java
@@ -1,9 +1,6 @@
 package io.pne.deploy.server.vertx.status.telegram;
 
-import com.payneteasy.telegram.bot.client.ITelegramService;
-import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
-import com.payneteasy.telegram.bot.client.model.Message;
-import com.payneteasy.telegram.bot.client.model.TelegramMessage;
+import io.pne.deploy.client.redmine.remote.impl.TelegramClient;
 import io.pne.deploy.server.api.task.Task;
 import io.pne.deploy.server.api.task.TaskId;
 
@@ -16,47 +13,39 @@ public class TelegramMessagesStore {
 
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     private final ConcurrentMap<TaskId, TelegramMessageHolder> map = new ConcurrentHashMap<>();
-    private final ITelegramService                             telegram;
+    private final TelegramClient telegram;
+    private final long           chatId;
 
-    public TelegramMessagesStore(ITelegramService telegram) {
+    public TelegramMessagesStore(TelegramClient telegram, long chatId) {
         this.telegram = telegram;
+        this.chatId   = chatId;
     }
 
-    public void addTask(Task aTask, TelegramMessage aTelegramMessage, String aText) {
-        Message message = aTelegramMessage.getResult();
+    public void addTask(Task aTask, long aMessageId, String aText) {
         map.put(aTask.id, TelegramMessageHolder.builder()
-                .messageId  ( message.getMessageId()    )
-                .chatId     ( message.getChat().getId() )
-                .text       ( aText + "\n"              )
-                .build()
-        );
+                .messageId(aMessageId)
+                .text(aText + "\n")
+                .build());
     }
 
     public void updateTask(Task aTask, String aOriginalText) {
-        String fixedText = aOriginalText
-                .replace("./bin/", "")
-                .replace(".sh", "")
-        ;
-        
-        TelegramMessageHolder holder = map.computeIfPresent(aTask.id, (taskId, old) -> old.toBuilder()
-                .text(old.getText()
-                        + "\n"
-                        + formatter.format(OffsetTime.now())
-                        +" "
-                        + fixedText)
-                .build());
-
-        if(holder == null) {
+        TelegramMessageHolder holder = map.get(aTask.id);
+        if (holder == null) {
             return;
         }
 
-        telegram.editMessageText(EditMessageTextRequest.builder()
-                .chatId(holder.getChatId())
-                .messageId(holder.getMessageId())
-                .text(holder.getText())
-                .build()
-        );
+        String fixedText = aOriginalText
+                .replace("./bin/", "")
+                .replace(".sh", "");
 
+        String candidate = holder.getText()
+                + "\n"
+                + formatter.format(OffsetTime.now())
+                + " "
+                + fixedText;
+
+        telegram.editMessage(chatId, holder.getMessageId(), candidate, null);
+        map.put(aTask.id, holder.toBuilder().text(candidate).build());
     }
 
     public void removeTask(Task aTask) {

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStore.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStore.java
@@ -11,6 +11,9 @@ import java.util.concurrent.ConcurrentMap;
 
 public class TelegramMessagesStore {
 
+    /** Telegram ограничивает сообщение ~4096 символами; берём запас. */
+    private static final int TG_SAFE_MAX = 4000;
+
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     private final ConcurrentMap<TaskId, TelegramMessageHolder> map = new ConcurrentHashMap<>();
     private final TelegramClient telegram;
@@ -38,14 +41,24 @@ public class TelegramMessagesStore {
                 .replace("./bin/", "")
                 .replace(".sh", "");
 
-        String candidate = holder.getText()
-                + "\n"
+        String line = "\n"
                 + formatter.format(OffsetTime.now())
                 + " "
                 + fixedText;
+        String candidate = holder.getText() + line;
 
-        telegram.editMessage(chatId, holder.getMessageId(), candidate, null);
-        map.put(aTask.id, holder.toBuilder().text(candidate).build());
+        if (candidate.length() <= TG_SAFE_MAX) {
+            telegram.editMessage(chatId, holder.getMessageId(), candidate, null);
+            map.put(aTask.id, holder.toBuilder().text(candidate).build());
+        } else {
+            // Roll-over: сообщение подошло к лимиту — начинаем новое и продолжаем редактировать его.
+            String start = "… (continued)" + line;
+            if (start.length() > TG_SAFE_MAX) {
+                start = start.substring(0, TG_SAFE_MAX);
+            }
+            long newMessageId = telegram.sendMessage(chatId, start, null);
+            map.put(aTask.id, holder.toBuilder().messageId(newMessageId).text(start).build());
+        }
     }
 
     public void removeTask(Task aTask) {

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStoreTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStoreTest.java
@@ -1,0 +1,59 @@
+package io.pne.deploy.server.vertx.status.telegram;
+
+import io.pne.deploy.client.redmine.remote.impl.TelegramClient;
+import io.pne.deploy.server.api.task.Task;
+import io.pne.deploy.server.api.task.TaskId;
+import io.pne.deploy.server.api.task.TaskParameters;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TelegramMessagesStoreTest {
+
+    private static final long CHAT_ID    = 42L;
+    private static final long FIRST_MSG  = 100L;
+    private static final long ROLLED_MSG = 200L;
+
+    private final TelegramClient       telegram = mock(TelegramClient.class);
+    private final TelegramMessagesStore store   = new TelegramMessagesStore(telegram, CHAT_ID);
+
+    @Test
+    public void rollsOverToNewMessageWhenTextExceedsLimit() {
+        // any roll-over send returns a distinct message id
+        when(telegram.sendMessage(anyLong(), anyString(), any())).thenReturn(ROLLED_MSG);
+
+        Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "deploy something", 0);
+        store.addTask(task, FIRST_MSG, "start");
+
+        // push enough long lines to blow past TG_SAFE_MAX (4000)
+        String bigLine = repeat("x", 1000);
+        for (int i = 0; i < 8; i++) {
+            store.updateTask(task, bigLine);
+        }
+
+        // before overflow: the original message was edited
+        verify(telegram, atLeastOnce()).editMessage(eq(CHAT_ID), eq(FIRST_MSG), anyString(), any());
+        // at overflow: a brand-new message was sent (roll-over)
+        verify(telegram, atLeastOnce()).sendMessage(eq(CHAT_ID), anyString(), any());
+        // after overflow: edits target the new (rolled-over) message
+        verify(telegram, atLeastOnce()).editMessage(eq(CHAT_ID), eq(ROLLED_MSG), anyString(), any());
+    }
+
+    private static String repeat(String s, int times) {
+        StringBuilder sb = new StringBuilder(s.length() * times);
+        for (int i = 0; i < times; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Что и зачем

Консолидация Telegram-интеграции на один клиент, починка лимита сообщения и rate-limit. Раньше было два способа ходить в Telegram Bot API (самописный HTTP в client-redmine + библиотека в server-vertx), а частые правки live-статуса упирались в лимиты Telegram (429).

## Коммиты
1. **refactor(redmine): send Telegram via telegram-bot-client library** — `RemoteTelegramServiceImpl` переведён на библиотеку `telegram-bot-client`.
2. **refactor(telegram): extract shared TelegramClient for both modules** — единый класс-обёртка `TelegramClient`; на него переведены и diff-уведомления, и live-статус.
3. **fix(telegram): roll over status message past 4096** — при подходе к лимиту статус продолжается новым сообщением (+ тест).
4. **feat(telegram): rate-limited queue with coalescing and 429 retry** — всё общение с Telegram идёт через один `TelegramClient` с очередью и одним daemon-воркером:
   - темп ≤ 1 обращение / `minIntervalMs` (дефолт 1100мс) на чат;
   - на **429** ждём `retry_after` и повторяем (нужен `telegram-bot-client` 1.0-10, который отдаёт статус + `retry_after`);
   - `editMessage` асинхронный с **коалесингом** (частые правки одного сообщения схлопываются до последнего текста) — прямое решение «слишком часто обновляем»;
   - единый экземпляр `TelegramClient` строится в `VertxServerApplication` и инжектится и в статус, и в diff → один лимит на чат для всего трафика.
   - Тест `TelegramClientTest`: коалесинг, 429-retry, возврат message_id.
   - Бамп `telegram-bot-client` 1.0-9 → **1.0-10**.

## Зависимость
Требует `telegram-bot-client` **1.0-10** (PR `evsinev/telegram-bot-client#6`, смёржен и опубликован в maven.pne.io): библиотека теперь отдаёт реальный HTTP-статус и `retry_after`.

## Проверка
`mvn -B -ntp verify` под JDK 21 — `BUILD SUCCESS`; зелёные `TelegramClientTest`, `TelegramMessagesStoreTest`, `DiffServiceProcessDiffTest`, `VertxAndWebsocketTest`. CI (чистый раннер, артефакт из maven.pne.io) — зелёный.
Оговорка: реальный HTTP в Telegram автотестами не покрыт (мокаем библиотеку/интерфейс); пейсинг по времени не проверяем (только коалесинг/ретрай/возврат id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
