### PR TITLE
Queue all Redmine mutations (enqueue*) and run diff on a managed pool

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
@@ -69,7 +69,7 @@ public class DiffServiceImpl implements DiffService {
             fullTelegramMessage.addAll(constructTelegramMessage(diffTask, diffLinks));
         }
 
-        redmine.addComment(issueId, fullRedmineMessage.toString());
+        redmine.enqueueAddComment(issueId, fullRedmineMessage.toString());
         telegram.sendMessages(fullTelegramMessage);
     }
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
@@ -20,6 +20,8 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessService {
 
@@ -31,6 +33,13 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
     private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
     private final String issueValidationScript;
     private final DiffService diffService;
+
+    /** Diff processing (GitLab compare + Redmine comment + Telegram) runs off the deploy thread on this queue. */
+    private final ExecutorService diffExecutor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "redmine-diff");
+        thread.setDaemon(true);
+        return thread;
+    });
 
 
     public RedmineIssuesProcessServiceImpl(IRemoteRedmineService redmine, IDeployService deployService, IRedmineRemoteConfig aConfig, IRemoteTelegramService telegram) {
@@ -60,7 +69,7 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
 
         } catch (Exception e) {
             LOG.error("Can't process issue {}", issue.issueId(), e);
-            redmine.changeStatusToFailed(
+            redmine.enqueueChangeStatusToFailed(
                     issue.issueId()
                     , "Task is FAILED: " + e.getMessage()
                             + "\n<pre>"
@@ -91,16 +100,16 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
         Task task = parseTask(aIssue.issueId(), aIssue.description());
         List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
         int issueId = aIssue.issueId();
-        new Thread(() -> {
+        diffExecutor.submit(() -> {
             try {
                 diffService.processDiff(diffTasks, issueId);
             } catch (Exception e) {
-                LOG.error("processDiff failed", e);
+                LOG.error("processDiff failed for issue {}", issueId, e);
             }
-        }, "diff-" + aIssue.issueId()).start();
-        redmine.changeStatusFromAcceptedToProcessing(aIssue.issueId(), "Starting task" + formatTask(task));
+        });
+        redmine.enqueueChangeStatusFromAcceptedToProcessing(aIssue.issueId(), "Starting task" + formatTask(task));
         deployService.runTask(task);
-        redmine.changeStatusToDone(aIssue.issueId(), "Task is DONE");
+        redmine.enqueueChangeStatusToDone(aIssue.issueId(), "Task is DONE");
     }
 
     private String formatTask(Task aTask) {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/IRemoteRedmineService.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/IRemoteRedmineService.java
@@ -8,11 +8,11 @@ import java.util.List;
 public interface IRemoteRedmineService {
     List<RedmineComment> getComments(int aIssueId);
 
-    void changeStatusFromAcceptedToProcessing(int aRedmineIssueId, String aMessage);
-    void changeStatusToDone(int aRedmineIssueId, String aMessage);
-    void changeStatusToFailed(int aRedmineIssueId, String aMessage);
+    void enqueueChangeStatusFromAcceptedToProcessing(int aRedmineIssueId, String aMessage);
+    void enqueueChangeStatusToDone(int aRedmineIssueId, String aMessage);
+    void enqueueChangeStatusToFailed(int aRedmineIssueId, String aMessage);
 
-    void addComment(int aIssueId, String aMessage);
+    void enqueueAddComment(int aIssueId, String aMessage);
 
     RedmineIssue getIssue(long aIssueId);
 }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
@@ -17,6 +17,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static com.payneteasy.http.client.api.HttpHeaders.singleHeader;
@@ -35,6 +37,13 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
     private final IHttpClient           client;
     private final Gson                  gson;
     private final HttpRequestParameters requestParameters = HttpRequestParameters.builder().timeouts(new HttpTimeouts(20_000, 20_000)).build();
+
+    /** All ticket mutations (status changes, comments) are serialized off the caller thread through this queue. */
+    private final ExecutorService writer = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "redmine-sender");
+        thread.setDaemon(true);
+        return thread;
+    });
 
     public RemoteRedmine4_2_10ServiceImpl(IRedmineRemoteConfig aConfig) {
         client = new HttpClientImpl();
@@ -137,28 +146,40 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
     }
 
     @Override
-    public void changeStatusFromAcceptedToProcessing(int aRedmineIssueId, String aMessage) {
-        LOG.info("changeStatusFromAcceptedToProcessing({}, {})", aRedmineIssueId, aMessage);
-        changeStatus(aRedmineIssueId, config.statusProcessingId(), aMessage);
+    public void enqueueChangeStatusFromAcceptedToProcessing(int aRedmineIssueId, String aMessage) {
+        LOG.info("enqueueChangeStatusFromAcceptedToProcessing({}, {})", aRedmineIssueId, aMessage);
+        submit("changeStatusFromAcceptedToProcessing", () -> changeStatus(aRedmineIssueId, config.statusProcessingId(), aMessage));
     }
 
     @Override
-    public void changeStatusToDone(int aRedmineIssueId, String aMessage) {
-        LOG.info("changeStatusToDone({}, {})", aRedmineIssueId, aMessage);
-        changeStatus(aRedmineIssueId, config.statusDoneId(), aMessage);
+    public void enqueueChangeStatusToDone(int aRedmineIssueId, String aMessage) {
+        LOG.info("enqueueChangeStatusToDone({}, {})", aRedmineIssueId, aMessage);
+        submit("changeStatusToDone", () -> changeStatus(aRedmineIssueId, config.statusDoneId(), aMessage));
     }
 
     @Override
-    public void changeStatusToFailed(int aRedmineIssueId, String aMessage) {
-        LOG.info("changeStatusToFailed({}, {})", aRedmineIssueId, aMessage);
-        changeStatus(aRedmineIssueId, config.statusFailedId(), aMessage);
+    public void enqueueChangeStatusToFailed(int aRedmineIssueId, String aMessage) {
+        LOG.info("enqueueChangeStatusToFailed({}, {})", aRedmineIssueId, aMessage);
+        submit("changeStatusToFailed", () -> changeStatus(aRedmineIssueId, config.statusFailedId(), aMessage));
     }
 
     @Override
-    public void addComment(int aIssueId, String aMessage) {
-        LOG.info("addComment({}, {})", aIssueId, aMessage);
-        RedmineIssue redmineIssue = getIssue(aIssueId);
-        changeStatus(aIssueId, redmineIssue.statusId(), aMessage);
+    public void enqueueAddComment(int aIssueId, String aMessage) {
+        LOG.info("enqueueAddComment({}, {})", aIssueId, aMessage);
+        submit("addComment", () -> {
+            RedmineIssue redmineIssue = getIssue(aIssueId);
+            changeStatus(aIssueId, redmineIssue.statusId(), aMessage);
+        });
+    }
+
+    private void submit(String aName, Runnable aAction) {
+        writer.submit(() -> {
+            try {
+                aAction.run();
+            } catch (Exception e) {
+                LOG.error("redmine {} failed", aName, e);
+            }
+        });
     }
 
     private ImmutableRedmineIssue mapIssue(RedmineIssueData issue) {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
@@ -47,7 +47,7 @@ public class DiffServiceProcessDiffTest {
         diffService.processDiff(singletonList(task), 42);
 
         ArgumentCaptor<String> comment = ArgumentCaptor.forClass(String.class);
-        verify(redmine).addComment(eq(42), comment.capture());
+        verify(redmine).enqueueAddComment(eq(42), comment.capture());
         assertTrue("redmine comment: " + comment.getValue(),
                 comment.getValue().contains("#119126 - Fix the bug"));
         assertTrue(comment.getValue().contains("No Issue - chore: cleanup"));

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImplTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImplTest.java
@@ -27,7 +27,7 @@ public class RemoteRedmine4_2_10ServiceImplTest {
     public void changeStatusFromAcceptedToProcessingTest() {
         IRedmineRemoteConfig config = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
         IRemoteRedmineService redmineService = new RemoteRedmine4_2_10ServiceImpl(config);
-        redmineService.changeStatusFromAcceptedToProcessing(124528, "changeStatusFromAcceptedToProcessingTest");
+        redmineService.enqueueChangeStatusFromAcceptedToProcessing(124528, "changeStatusFromAcceptedToProcessingTest");
     }
 
     @Test
@@ -35,7 +35,7 @@ public class RemoteRedmine4_2_10ServiceImplTest {
     public void changeStatusToDoneTest() {
         IRedmineRemoteConfig config = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
         IRemoteRedmineService redmineService = new RemoteRedmine4_2_10ServiceImpl(config);
-        redmineService.changeStatusToDone(124528, "changeStatusToDoneTest");
+        redmineService.enqueueChangeStatusToDone(124528, "changeStatusToDoneTest");
     }
 
     @Test
@@ -43,7 +43,7 @@ public class RemoteRedmine4_2_10ServiceImplTest {
     public void changeStatusToFailedTest() {
         IRedmineRemoteConfig config = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
         IRemoteRedmineService redmineService = new RemoteRedmine4_2_10ServiceImpl(config);
-        redmineService.changeStatusToFailed(124528, "changeStatusToFailed");
+        redmineService.enqueueChangeStatusToFailed(124528, "changeStatusToFailed");
     }
 
     @Test
@@ -51,6 +51,6 @@ public class RemoteRedmine4_2_10ServiceImplTest {
     public void addCommentTest() {
         IRedmineRemoteConfig config = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
         IRemoteRedmineService redmineService = new RemoteRedmine4_2_10ServiceImpl(config);
-        redmineService.changeStatusToFailed(124528, "addCommentTest");
+        redmineService.enqueueChangeStatusToFailed(124528, "addCommentTest");
     }
 }


### PR DESCRIPTION
## Что и зачем

Была «проблема с Thread»: `RedmineIssuesProcessServiceImpl.processIssue` запускал diff-обработку сырым fire-and-forget `new Thread(...)` на каждый issue. Плюс обращения к Redmine на запись шли синхронно из разных мест. Переводим **все мутации Redmine на очередь** и явно называем их с префиксом `enqueue`, а diff-работу — на управляемый пул вместо сырого потока.

## Изменения
- **`IRemoteRedmineService`** — методы-мутации переименованы с префиксом `enqueue`:
  `enqueueChangeStatusFromAcceptedToProcessing`, `enqueueChangeStatusToDone`, `enqueueChangeStatusToFailed`, `enqueueAddComment`. Чтения (`getIssue`, `getComments`) — без изменений (возвращают значение).
- **`RemoteRedmine4_2_10ServiceImpl`** — внутренняя очередь записи: один daemon-воркер `redmine-sender` (`Executors.newSingleThreadExecutor`). `enqueue*` кладут существующую синхронную HTTP-логику в очередь (ошибки логируются); порядок FIFO сохраняется. Чтения остаются синхронными.
- **`RedmineIssuesProcessServiceImpl`** — статус-вызовы переведены на `enqueue*`; сырой `new Thread(...)` заменён на управляемый daemon-пул `redmine-diff` (`diffExecutor.submit(...)`). diff остаётся асинхронным намеренно: внутри него `gitlab.getTagDiff` и `getIssue` синхронны и не должны блокировать/ронять деплой.
- **`DiffServiceImpl`** — `redmine.addComment(...)` → `redmine.enqueueAddComment(...)`.
- Тесты обновлены под новые имена (`DiffServiceProcessDiffTest`, `@Ignore` `RemoteRedmine4_2_10ServiceImplTest`).

## Семантика
`processIssue`: `enqueueChangeStatusFromAcceptedToProcessing` → `runTask` (синхронно) → `enqueueChangeStatusToDone`. Очередь `redmine-sender` (FIFO) сохраняет порядок статусов и обрабатывает их вне деплой-потока. diff-работа исполняется на `redmine-diff`, её `enqueueAddComment` уходит в ту же `redmine-sender` — без сырых потоков.

## Проверка
`mvn -B -ntp verify` под JDK 21 — `BUILD SUCCESS`; зелёные `DiffServiceProcessDiffTest`, `TelegramClientTest`, `TelegramMessagesStoreTest`, `VertxAndWebsocketTest`. Грепом: старых имён и `new Thread`-на-issue не осталось.

## Вне объёма
- Rate-limit/429 для Redmine (в отличие от Telegram) — очередь пока просто FIFO без пейсинга.
- Явная остановка executor'ов на shutdown — потоки daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
