### PR TITLE
Durable queues + dead-letter + Prometheus metrics (Telegram & Redmine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gen/
 classes/
 gen-external-apklibs/
 .vertx
+/queue/

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/IRedmineRemoteConfig.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/IRedmineRemoteConfig.java
@@ -38,6 +38,9 @@ public interface IRedmineRemoteConfig extends IStartupConfig {
     @AStartupParameter(name = "STATUS_PAGE_PATH", value = "/deploy/status")
     String statusPageHtmlPath();
 
+    @AStartupParameter(name = "QUEUE_DIR", value = "./queue")
+    String queueDir();
+
     @AStartupParameter(name = "GITLAB_URL", value = "")
     String gitlabUrl();
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
@@ -10,6 +10,7 @@ import io.pne.deploy.client.redmine.remote.model.ImmutableRedmineComment;
 import io.pne.deploy.client.redmine.remote.model.ImmutableRedmineIssue;
 import io.pne.deploy.client.redmine.remote.model.RedmineComment;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
+import io.pne.deploy.client.redmine.remote.queue.Backoff;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,11 +186,30 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
     }
 
     private void runOp(String aFile, RedmineOp aOp) {
+        for (int attempt = 1; attempt <= Backoff.MAX_ATTEMPTS; attempt++) {
+            try {
+                execute(aOp);
+                spool.remove(aFile);
+                return;
+            } catch (Exception e) {
+                LOG.warn("redmine {} for issue {} failed (attempt {}/{})", aOp.kind, aOp.issueId, attempt, Backoff.MAX_ATTEMPTS, e);
+                if (attempt < Backoff.MAX_ATTEMPTS) {
+                    sleep(Backoff.delayMs(attempt));
+                }
+            }
+        }
+        LOG.error("redmine {} for issue {} dead-lettered after {} attempts", aOp.kind, aOp.issueId, Backoff.MAX_ATTEMPTS);
+        spool.deadLetter(aFile);
+    }
+
+    private static void sleep(long aMs) {
+        if (aMs <= 0) {
+            return;
+        }
         try {
-            execute(aOp);
-            spool.remove(aFile);
-        } catch (Exception e) {
-            LOG.error("redmine {} for issue {} failed (kept for retry on restart)", aOp.kind, aOp.issueId, e);
+            Thread.sleep(aMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 
 import static com.payneteasy.http.client.api.HttpHeaders.singleHeader;
@@ -49,10 +50,16 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
     });
 
     private final PersistentSpool spool;
+    private final LongConsumer    sendLatencyNanos; // nullable: records duration of a successful mutation call
 
     public RemoteRedmine4_2_10ServiceImpl(IRedmineRemoteConfig aConfig) {
+        this(aConfig, null);
+    }
+
+    public RemoteRedmine4_2_10ServiceImpl(IRedmineRemoteConfig aConfig, LongConsumer aSendLatencyNanos) {
         client = new HttpClientImpl();
         config = aConfig;
+        sendLatencyNanos = aSendLatencyNanos;
         gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
         spool = new PersistentSpool(new File(aConfig.queueDir(), "redmine"));
         // resend operations that survived a restart (were persisted but not confirmed sent)
@@ -192,7 +199,9 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
     private void runOp(String aFile, RedmineOp aOp) {
         for (int attempt = 1; attempt <= Backoff.MAX_ATTEMPTS; attempt++) {
             try {
+                long start = System.nanoTime();
                 execute(aOp);
+                recordLatency(start);
                 spool.remove(aFile);
                 return;
             } catch (Exception e) {
@@ -204,6 +213,12 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
         }
         LOG.error("redmine {} for issue {} dead-lettered after {} attempts", aOp.kind, aOp.issueId, Backoff.MAX_ATTEMPTS);
         spool.deadLetter(aFile);
+    }
+
+    private void recordLatency(long aStartNanos) {
+        if (sendLatencyNanos != null) {
+            sendLatencyNanos.accept(System.nanoTime() - aStartNanos);
+        }
     }
 
     private static void sleep(long aMs) {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
@@ -180,6 +180,10 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
         enqueue(new RedmineOp(RedmineOp.COMMENT, aIssueId, null, aMessage));
     }
 
+    public PersistentSpool getSpool() {
+        return spool;
+    }
+
     private void enqueue(RedmineOp aOp) {
         String file = spool.append(gson.toJson(aOp));
         writer.submit(() -> runOp(file, aOp));

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
@@ -10,9 +10,11 @@ import io.pne.deploy.client.redmine.remote.model.ImmutableRedmineComment;
 import io.pne.deploy.client.redmine.remote.model.ImmutableRedmineIssue;
 import io.pne.deploy.client.redmine.remote.model.RedmineComment;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
+import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -45,10 +47,18 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
         return thread;
     });
 
+    private final PersistentSpool spool;
+
     public RemoteRedmine4_2_10ServiceImpl(IRedmineRemoteConfig aConfig) {
         client = new HttpClientImpl();
         config = aConfig;
         gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+        spool = new PersistentSpool(new File(aConfig.queueDir(), "redmine"));
+        // resend operations that survived a restart (were persisted but not confirmed sent)
+        for (PersistentSpool.Stored stored : spool.loadAll()) {
+            RedmineOp op = gson.fromJson(stored.getJson(), RedmineOp.class);
+            writer.submit(() -> runOp(stored.getFileName(), op));
+        }
     }
 
     @Override
@@ -148,38 +158,70 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
     @Override
     public void enqueueChangeStatusFromAcceptedToProcessing(int aRedmineIssueId, String aMessage) {
         LOG.info("enqueueChangeStatusFromAcceptedToProcessing({}, {})", aRedmineIssueId, aMessage);
-        submit("changeStatusFromAcceptedToProcessing", () -> changeStatus(aRedmineIssueId, config.statusProcessingId(), aMessage));
+        enqueue(new RedmineOp(RedmineOp.STATUS, aRedmineIssueId, config.statusProcessingId(), aMessage));
     }
 
     @Override
     public void enqueueChangeStatusToDone(int aRedmineIssueId, String aMessage) {
         LOG.info("enqueueChangeStatusToDone({}, {})", aRedmineIssueId, aMessage);
-        submit("changeStatusToDone", () -> changeStatus(aRedmineIssueId, config.statusDoneId(), aMessage));
+        enqueue(new RedmineOp(RedmineOp.STATUS, aRedmineIssueId, config.statusDoneId(), aMessage));
     }
 
     @Override
     public void enqueueChangeStatusToFailed(int aRedmineIssueId, String aMessage) {
         LOG.info("enqueueChangeStatusToFailed({}, {})", aRedmineIssueId, aMessage);
-        submit("changeStatusToFailed", () -> changeStatus(aRedmineIssueId, config.statusFailedId(), aMessage));
+        enqueue(new RedmineOp(RedmineOp.STATUS, aRedmineIssueId, config.statusFailedId(), aMessage));
     }
 
     @Override
     public void enqueueAddComment(int aIssueId, String aMessage) {
         LOG.info("enqueueAddComment({}, {})", aIssueId, aMessage);
-        submit("addComment", () -> {
-            RedmineIssue redmineIssue = getIssue(aIssueId);
-            changeStatus(aIssueId, redmineIssue.statusId(), aMessage);
-        });
+        enqueue(new RedmineOp(RedmineOp.COMMENT, aIssueId, null, aMessage));
     }
 
-    private void submit(String aName, Runnable aAction) {
-        writer.submit(() -> {
-            try {
-                aAction.run();
-            } catch (Exception e) {
-                LOG.error("redmine {} failed", aName, e);
-            }
-        });
+    private void enqueue(RedmineOp aOp) {
+        String file = spool.append(gson.toJson(aOp));
+        writer.submit(() -> runOp(file, aOp));
+    }
+
+    private void runOp(String aFile, RedmineOp aOp) {
+        try {
+            execute(aOp);
+            spool.remove(aFile);
+        } catch (Exception e) {
+            LOG.error("redmine {} for issue {} failed (kept for retry on restart)", aOp.kind, aOp.issueId, e);
+        }
+    }
+
+    private void execute(RedmineOp aOp) {
+        if (RedmineOp.COMMENT.equals(aOp.kind)) {
+            RedmineIssue redmineIssue = getIssue(aOp.issueId);
+            changeStatus(aOp.issueId, redmineIssue.statusId(), aOp.message);
+        } else {
+            changeStatus(aOp.issueId, aOp.statusId, aOp.message);
+        }
+    }
+
+    /** Persisted, replayable Redmine mutation. */
+    private static final class RedmineOp {
+        static final String STATUS  = "STATUS";
+        static final String COMMENT = "COMMENT";
+
+        String  kind;
+        int     issueId;
+        Integer statusId;
+        String  message;
+
+        RedmineOp() {
+            // for gson
+        }
+
+        RedmineOp(String aKind, int aIssueId, Integer aStatusId, String aMessage) {
+            this.kind     = aKind;
+            this.issueId  = aIssueId;
+            this.statusId = aStatusId;
+            this.message  = aMessage;
+        }
     }
 
     private ImmutableRedmineIssue mapIssue(RedmineIssueData issue) {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
@@ -3,6 +3,7 @@ package io.pne.deploy.client.redmine.remote.impl;
 import com.payneteasy.telegram.bot.client.model.ParseMode;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 
+import java.io.File;
 import java.util.List;
 
 public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
@@ -12,7 +13,7 @@ public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
     private final TelegramClient telegram;
 
     public RemoteTelegramServiceImpl(IRedmineRemoteConfig aConfig) {
-        this(new TelegramClient(aConfig.getTelegramToken()), aConfig);
+        this(new TelegramClient(aConfig.getTelegramToken(), new File(aConfig.queueDir(), "telegram")), aConfig);
     }
 
     public RemoteTelegramServiceImpl(TelegramClient aTelegram, IRedmineRemoteConfig aConfig) {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -9,6 +9,7 @@ import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
 import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
 import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
 import com.payneteasy.telegram.bot.client.model.ParseMode;
+import io.pne.deploy.client.redmine.remote.queue.Backoff;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +33,6 @@ public class TelegramClient {
     private static final Logger LOG = LoggerFactory.getLogger(TelegramClient.class);
 
     private static final long DEFAULT_MIN_INTERVAL_MS = 1100;
-    private static final int  MAX_RETRIES             = 5;
 
     private final ITelegramService telegram;
     private final long             minIntervalMs;
@@ -108,11 +108,11 @@ public class TelegramClient {
                 aFuture.complete(id);
             }
         } catch (RuntimeException e) {
-            // keep the spool file — the message will be retried on the next restart
+            spool.deadLetter(aFile);
             if (aFuture != null) {
                 aFuture.completeExceptionally(e);
             } else {
-                LOG.error("telegram send failed (kept for retry on restart)", e);
+                LOG.error("telegram send dead-lettered after {} attempts", Backoff.MAX_ATTEMPTS, e);
             }
         }
     }
@@ -137,7 +137,8 @@ public class TelegramClient {
             });
             spool.remove(edit.fileName);
         } catch (RuntimeException e) {
-            LOG.error("telegram edit failed (kept for retry on restart)", e);
+            spool.deadLetter(edit.fileName);
+            LOG.error("telegram edit dead-lettered after {} attempts", Backoff.MAX_ATTEMPTS, e);
         }
     }
 
@@ -175,23 +176,32 @@ public class TelegramClient {
     }
 
     private <T> T callWithRetry(Supplier<T> aCall) {
-        for (int attempt = 1; ; attempt++) {
+        RuntimeException last = null;
+        for (int attempt = 1; attempt <= Backoff.MAX_ATTEMPTS; attempt++) {
             awaitRateLimit();
             try {
                 return aCall.get();
-            } catch (TelegramCommandException e) {
-                Integer code = e.getErrorCode();
-                if (code != null && code == 429 && attempt <= MAX_RETRIES) {
-                    long waitMs = e.getRetryAfter() != null ? e.getRetryAfter() * 1000L : minIntervalMs;
-                    LOG.warn("Telegram 429, retry #{} after {}ms", attempt, waitMs);
-                    sleep(waitMs);
-                    continue;
+            } catch (RuntimeException e) {
+                last = e;
+                LOG.warn("Telegram call failed (attempt {}/{})", attempt, Backoff.MAX_ATTEMPTS, e);
+                if (attempt < Backoff.MAX_ATTEMPTS) {
+                    sleep(backoffMs(e, attempt));
                 }
-                throw e;
             } finally {
                 lastCallAt = System.currentTimeMillis();
             }
         }
+        throw last;
+    }
+
+    private static long backoffMs(RuntimeException e, int aAttempt) {
+        if (e instanceof TelegramCommandException) {
+            TelegramCommandException tce = (TelegramCommandException) e;
+            if (tce.getErrorCode() != null && tce.getErrorCode() == 429 && tce.getRetryAfter() != null) {
+                return tce.getRetryAfter() * 1000L;
+            }
+        }
+        return Backoff.delayMs(aAttempt);
     }
 
     private void awaitRateLimit() {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -94,6 +94,10 @@ public class TelegramClient {
         }
     }
 
+    public PersistentSpool getSpool() {
+        return spool;
+    }
+
     private void runSend(String aFile, TelegramOp aOp, CompletableFuture<Long> aFuture) {
         try {
             long id = callWithRetry(() -> telegram.sendMessage(TelegramMessageRequest.builder()

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -1,5 +1,7 @@
 package io.pne.deploy.client.redmine.remote.impl;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.payneteasy.telegram.bot.client.ITelegramService;
 import com.payneteasy.telegram.bot.client.TelegramCommandException;
 import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
@@ -7,9 +9,11 @@ import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
 import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
 import com.payneteasy.telegram.bot.client.messages.TelegramMessageRequest;
 import com.payneteasy.telegram.bot.client.model.ParseMode;
+import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -20,8 +24,8 @@ import java.util.function.Supplier;
 
 /**
  * Единственная точка работы с telegram-bot-client. Все вызовы идут через один поток-воркер с
- * ограничением темпа (не чаще одного обращения в {@code minIntervalMs}) и повтором на 429 по
- * {@code retry_after}. Частые правки одного и того же сообщения коалесятся до последнего текста.
+ * ограничением темпа и повтором на 429 по {@code retry_after}. Частые правки одного сообщения коалесятся.
+ * Операции персистятся на диск (spool) и переотправляются после рестарта (at-least-once).
  */
 public class TelegramClient {
 
@@ -32,40 +36,36 @@ public class TelegramClient {
 
     private final ITelegramService telegram;
     private final long             minIntervalMs;
+    private final PersistentSpool  spool;
+    private final Gson             gson = new GsonBuilder().disableHtmlEscaping().create();
 
     private final BlockingQueue<Runnable> queue        = new LinkedBlockingQueue<>();
     private final Map<Long, PendingEdit>  pendingEdits = new HashMap<>(); // guarded by itself
 
     private volatile long lastCallAt = 0;
 
-    public TelegramClient(String aToken) {
-        this(new TelegramServiceImpl(new TelegramHttpClientImpl(aToken)), DEFAULT_MIN_INTERVAL_MS);
+    public TelegramClient(String aToken, File aSpoolDir) {
+        this(new TelegramServiceImpl(new TelegramHttpClientImpl(aToken)), DEFAULT_MIN_INTERVAL_MS, aSpoolDir);
     }
 
-    public TelegramClient(ITelegramService aTelegram, long aMinIntervalMs) {
+    public TelegramClient(ITelegramService aTelegram, long aMinIntervalMs, File aSpoolDir) {
         this.telegram      = aTelegram;
         this.minIntervalMs = aMinIntervalMs;
+        this.spool         = new PersistentSpool(aSpoolDir);
+
         Thread worker = new Thread(this::runWorker, "telegram-sender");
         worker.setDaemon(true);
         worker.start();
+
+        replay();
     }
 
     /** Блокирующая отправка нового сообщения; возвращает message_id. */
     public long sendMessage(long aChatId, String aText, ParseMode aParseMode) {
+        TelegramOp op   = TelegramOp.send(aChatId, aText, aParseMode);
+        String     file = spool.append(gson.toJson(op));
         CompletableFuture<Long> future = new CompletableFuture<>();
-        queue.add(() -> {
-            try {
-                future.complete(callWithRetry(() -> telegram.sendMessage(TelegramMessageRequest.builder()
-                                .chatId(aChatId)
-                                .text(aText)
-                                .parseMode(aParseMode)
-                                .build())
-                        .getResult()
-                        .getMessageId()));
-            } catch (RuntimeException e) {
-                future.completeExceptionally(e);
-            }
-        });
+        queue.add(() -> runSend(file, op, future));
         try {
             return future.get();
         } catch (InterruptedException e) {
@@ -80,15 +80,40 @@ public class TelegramClient {
         }
     }
 
-    /** Асинхронная правка с коалесингом: сохраняем последний текст и планируем один вызов на messageId. */
+    /** Асинхронная правка с коалесингом: сохраняем последний текст (overwrite в spool) и планируем один вызов. */
     public void editMessage(long aChatId, long aMessageId, String aText, ParseMode aParseMode) {
-        boolean schedule;
+        TelegramOp op   = TelegramOp.edit(aChatId, aMessageId, aText, aParseMode);
+        String     file = spool.put(editKey(aChatId, aMessageId), gson.toJson(op));
+        boolean    schedule;
         synchronized (pendingEdits) {
             schedule = !pendingEdits.containsKey(aMessageId);
-            pendingEdits.put(aMessageId, new PendingEdit(aChatId, aText, aParseMode));
+            pendingEdits.put(aMessageId, new PendingEdit(aChatId, aText, aParseMode, file));
         }
         if (schedule) {
             queue.add(() -> flushEdit(aMessageId));
+        }
+    }
+
+    private void runSend(String aFile, TelegramOp aOp, CompletableFuture<Long> aFuture) {
+        try {
+            long id = callWithRetry(() -> telegram.sendMessage(TelegramMessageRequest.builder()
+                            .chatId(aOp.chatId)
+                            .text(aOp.text)
+                            .parseMode(parseMode(aOp.parseMode))
+                            .build())
+                    .getResult()
+                    .getMessageId());
+            spool.remove(aFile);
+            if (aFuture != null) {
+                aFuture.complete(id);
+            }
+        } catch (RuntimeException e) {
+            // keep the spool file — the message will be retried on the next restart
+            if (aFuture != null) {
+                aFuture.completeExceptionally(e);
+            } else {
+                LOG.error("telegram send failed (kept for retry on restart)", e);
+            }
         }
     }
 
@@ -100,15 +125,36 @@ public class TelegramClient {
         if (edit == null) {
             return;
         }
-        callWithRetry(() -> {
-            telegram.editMessageText(EditMessageTextRequest.builder()
-                    .chatId(edit.chatId)
-                    .messageId(aMessageId)
-                    .text(edit.text)
-                    .parseMode(edit.parseMode)
-                    .build());
-            return null;
-        });
+        try {
+            callWithRetry(() -> {
+                telegram.editMessageText(EditMessageTextRequest.builder()
+                        .chatId(edit.chatId)
+                        .messageId(aMessageId)
+                        .text(edit.text)
+                        .parseMode(edit.parseMode)
+                        .build());
+                return null;
+            });
+            spool.remove(edit.fileName);
+        } catch (RuntimeException e) {
+            LOG.error("telegram edit failed (kept for retry on restart)", e);
+        }
+    }
+
+    /** Re-enqueue operations that were persisted but not confirmed sent before a restart. */
+    private void replay() {
+        for (PersistentSpool.Stored stored : spool.loadAll()) {
+            TelegramOp op = gson.fromJson(stored.getJson(), TelegramOp.class);
+            if (TelegramOp.EDIT.equals(op.kind) && op.messageId != null) {
+                synchronized (pendingEdits) {
+                    pendingEdits.put(op.messageId, new PendingEdit(op.chatId, op.text, parseMode(op.parseMode), stored.getFileName()));
+                }
+                long messageId = op.messageId;
+                queue.add(() -> flushEdit(messageId));
+            } else {
+                queue.add(() -> runSend(stored.getFileName(), op, null));
+            }
+        }
     }
 
     private void runWorker() {
@@ -163,15 +209,60 @@ public class TelegramClient {
         }
     }
 
+    private static ParseMode parseMode(String aName) {
+        return aName == null ? null : ParseMode.valueOf(aName);
+    }
+
+    private static String editKey(long aChatId, long aMessageId) {
+        return "edit-" + aChatId + "-" + aMessageId;
+    }
+
     private static final class PendingEdit {
         final long      chatId;
         final String    text;
         final ParseMode parseMode;
+        final String    fileName;
 
-        PendingEdit(long aChatId, String aText, ParseMode aParseMode) {
+        PendingEdit(long aChatId, String aText, ParseMode aParseMode, String aFileName) {
             this.chatId    = aChatId;
             this.text      = aText;
             this.parseMode = aParseMode;
+            this.fileName  = aFileName;
+        }
+    }
+
+    /** Persisted, replayable Telegram operation. */
+    private static final class TelegramOp {
+        static final String SEND = "SEND";
+        static final String EDIT = "EDIT";
+
+        String kind;
+        long   chatId;
+        Long   messageId;
+        String text;
+        String parseMode; // ParseMode name or null
+
+        TelegramOp() {
+            // for gson
+        }
+
+        static TelegramOp send(long aChatId, String aText, ParseMode aParseMode) {
+            TelegramOp op = new TelegramOp();
+            op.kind      = SEND;
+            op.chatId    = aChatId;
+            op.text      = aText;
+            op.parseMode = aParseMode == null ? null : aParseMode.name();
+            return op;
+        }
+
+        static TelegramOp edit(long aChatId, long aMessageId, String aText, ParseMode aParseMode) {
+            TelegramOp op = new TelegramOp();
+            op.kind      = EDIT;
+            op.chatId    = aChatId;
+            op.messageId = aMessageId;
+            op.text      = aText;
+            op.parseMode = aParseMode == null ? null : aParseMode.name();
+            return op;
         }
     }
 }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -21,6 +21,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -37,6 +38,7 @@ public class TelegramClient {
     private final ITelegramService telegram;
     private final long             minIntervalMs;
     private final PersistentSpool  spool;
+    private final LongConsumer     sendLatencyNanos; // nullable: records duration of a successful API call
     private final Gson             gson = new GsonBuilder().disableHtmlEscaping().create();
 
     private final BlockingQueue<Runnable> queue        = new LinkedBlockingQueue<>();
@@ -45,13 +47,22 @@ public class TelegramClient {
     private volatile long lastCallAt = 0;
 
     public TelegramClient(String aToken, File aSpoolDir) {
-        this(new TelegramServiceImpl(new TelegramHttpClientImpl(aToken)), DEFAULT_MIN_INTERVAL_MS, aSpoolDir);
+        this(aToken, aSpoolDir, null);
+    }
+
+    public TelegramClient(String aToken, File aSpoolDir, LongConsumer aSendLatencyNanos) {
+        this(new TelegramServiceImpl(new TelegramHttpClientImpl(aToken)), DEFAULT_MIN_INTERVAL_MS, aSpoolDir, aSendLatencyNanos);
     }
 
     public TelegramClient(ITelegramService aTelegram, long aMinIntervalMs, File aSpoolDir) {
-        this.telegram      = aTelegram;
-        this.minIntervalMs = aMinIntervalMs;
-        this.spool         = new PersistentSpool(aSpoolDir);
+        this(aTelegram, aMinIntervalMs, aSpoolDir, null);
+    }
+
+    public TelegramClient(ITelegramService aTelegram, long aMinIntervalMs, File aSpoolDir, LongConsumer aSendLatencyNanos) {
+        this.telegram         = aTelegram;
+        this.minIntervalMs    = aMinIntervalMs;
+        this.spool            = new PersistentSpool(aSpoolDir);
+        this.sendLatencyNanos = aSendLatencyNanos;
 
         Thread worker = new Thread(this::runWorker, "telegram-sender");
         worker.setDaemon(true);
@@ -184,7 +195,10 @@ public class TelegramClient {
         for (int attempt = 1; attempt <= Backoff.MAX_ATTEMPTS; attempt++) {
             awaitRateLimit();
             try {
-                return aCall.get();
+                long start = System.nanoTime();
+                T result = aCall.get();
+                recordLatency(start);
+                return result;
             } catch (RuntimeException e) {
                 last = e;
                 LOG.warn("Telegram call failed (attempt {}/{})", attempt, Backoff.MAX_ATTEMPTS, e);
@@ -206,6 +220,12 @@ public class TelegramClient {
             }
         }
         return Backoff.delayMs(aAttempt);
+    }
+
+    private void recordLatency(long aStartNanos) {
+        if (sendLatencyNanos != null) {
+            sendLatencyNanos.accept(System.nanoTime() - aStartNanos);
+        }
     }
 
     private void awaitRateLimit() {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/Backoff.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/Backoff.java
@@ -1,0 +1,20 @@
+package io.pne.deploy.client.redmine.remote.queue;
+
+/** Общая политика повторов для durable-очередей: не больше {@link #MAX_ATTEMPTS} попыток с экспоненциальным backoff. */
+public final class Backoff {
+
+    /** Максимум попыток отправки одной операции за прогон; после — dead-letter. */
+    public static final int MAX_ATTEMPTS = 10;
+
+    private static final long BASE_MS = 1000;
+    private static final long MAX_MS  = 60_000;
+
+    private Backoff() {
+    }
+
+    /** Пауза перед попыткой {@code aAttempt} (1-based): экспоненциальная, с потолком {@value #MAX_MS} мс. */
+    public static long delayMs(int aAttempt) {
+        int shift = Math.min(Math.max(aAttempt - 1, 0), 20);
+        return Math.min(BASE_MS << shift, MAX_MS);
+    }
+}

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpool.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpool.java
@@ -23,8 +23,9 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class PersistentSpool {
 
-    private static final Logger LOG    = LoggerFactory.getLogger(PersistentSpool.class);
-    private static final String SUFFIX = ".json";
+    private static final Logger LOG         = LoggerFactory.getLogger(PersistentSpool.class);
+    private static final String SUFFIX      = ".json";
+    private static final String DEAD_SUBDIR = "dead";
 
     private final File       dir;
     private final AtomicLong sequence;
@@ -56,6 +57,22 @@ public class PersistentSpool {
             Files.deleteIfExists(new File(dir, aFileName).toPath());
         } catch (IOException e) {
             LOG.warn("Cannot remove spool file {}", aFileName, e);
+        }
+    }
+
+    /** Move a give-up operation into the {@code dead/} sub-directory so it stops being retried but is kept. */
+    public synchronized void deadLetter(String aFileName) {
+        File deadDir = new File(dir, DEAD_SUBDIR);
+        if (!deadDir.exists() && !deadDir.mkdirs()) {
+            LOG.warn("Cannot create dead-letter dir {}", deadDir);
+            return;
+        }
+        try {
+            Files.move(new File(dir, aFileName).toPath(), new File(deadDir, aFileName).toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+            LOG.warn("Moved {} to dead-letter dir {}", aFileName, deadDir);
+        } catch (IOException e) {
+            LOG.warn("Cannot dead-letter spool file {}", aFileName, e);
         }
     }
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpool.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpool.java
@@ -1,0 +1,132 @@
+package io.pne.deploy.client.redmine.remote.queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Небольшой durable-спул: одна операция = один {@code *.json} файл. Пишем файл ДО отправки, удаляем ПОСЛЕ успеха,
+ * {@link #loadAll()} при старте поднимает незакрытые. {@link #append} — FIFO по имени (счётчик), {@link #put} —
+ * overwrite по ключу (коалесинг). Запись атомарна (temp-файл + move).
+ */
+public class PersistentSpool {
+
+    private static final Logger LOG    = LoggerFactory.getLogger(PersistentSpool.class);
+    private static final String SUFFIX = ".json";
+
+    private final File       dir;
+    private final AtomicLong sequence;
+
+    public PersistentSpool(File aDir) {
+        this.dir = aDir;
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IllegalStateException("Cannot create spool dir " + dir);
+        }
+        this.sequence = new AtomicLong(maxSequence());
+    }
+
+    /** Последовательная запись (FIFO). @return имя файла для последующего {@link #remove}. */
+    public synchronized String append(String aJson) {
+        String name = String.format("%020d%s", sequence.incrementAndGet(), SUFFIX);
+        writeAtomic(name, aJson);
+        return name;
+    }
+
+    /** Запись по ключу (overwrite = коалесинг). @return имя файла. */
+    public synchronized String put(String aKey, String aJson) {
+        String name = sanitize(aKey) + SUFFIX;
+        writeAtomic(name, aJson);
+        return name;
+    }
+
+    public synchronized void remove(String aFileName) {
+        try {
+            Files.deleteIfExists(new File(dir, aFileName).toPath());
+        } catch (IOException e) {
+            LOG.warn("Cannot remove spool file {}", aFileName, e);
+        }
+    }
+
+    public synchronized List<Stored> loadAll() {
+        File[] files = dir.listFiles((d, name) -> name.endsWith(SUFFIX));
+        List<Stored> result = new ArrayList<>();
+        if (files == null) {
+            return result;
+        }
+        Arrays.sort(files);
+        for (File file : files) {
+            try {
+                String json = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+                result.add(new Stored(file.getName(), json));
+            } catch (IOException e) {
+                LOG.warn("Cannot read spool file {}", file, e);
+            }
+        }
+        return result;
+    }
+
+    private void writeAtomic(String aName, String aJson) {
+        Path target = new File(dir, aName).toPath();
+        Path tmp    = new File(dir, aName + ".tmp").toPath();
+        try {
+            Files.write(tmp, aJson.getBytes(StandardCharsets.UTF_8));
+            try {
+                Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot write spool file " + aName, e);
+        }
+    }
+
+    private long maxSequence() {
+        File[] files = dir.listFiles((d, name) -> name.endsWith(SUFFIX));
+        long max = 0;
+        if (files != null) {
+            for (File file : files) {
+                String base = file.getName().substring(0, file.getName().length() - SUFFIX.length());
+                try {
+                    max = Math.max(max, Long.parseLong(base));
+                } catch (NumberFormatException ignore) {
+                    // keyed entries (edit-...) are not sequential — skip
+                }
+            }
+        }
+        return max;
+    }
+
+    private static String sanitize(String aKey) {
+        return aKey.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+
+    public static final class Stored {
+        private final String fileName;
+        private final String json;
+
+        public Stored(String aFileName, String aJson) {
+            this.fileName = aFileName;
+            this.json     = aJson;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public String getJson() {
+            return json;
+        }
+    }
+}

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpool.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpool.java
@@ -29,6 +29,8 @@ public class PersistentSpool {
 
     private final File       dir;
     private final AtomicLong sequence;
+    private final AtomicLong sent         = new AtomicLong();
+    private final AtomicLong deadLettered = new AtomicLong();
 
     public PersistentSpool(File aDir) {
         this.dir = aDir;
@@ -58,6 +60,7 @@ public class PersistentSpool {
         } catch (IOException e) {
             LOG.warn("Cannot remove spool file {}", aFileName, e);
         }
+        sent.incrementAndGet();
     }
 
     /** Move a give-up operation into the {@code dead/} sub-directory so it stops being retried but is kept. */
@@ -74,6 +77,29 @@ public class PersistentSpool {
         } catch (IOException e) {
             LOG.warn("Cannot dead-letter spool file {}", aFileName, e);
         }
+        deadLettered.incrementAndGet();
+    }
+
+    /** Number of active (pending) operations currently spooled. */
+    public synchronized int size() {
+        File[] files = dir.listFiles((d, name) -> name.endsWith(SUFFIX));
+        return files == null ? 0 : files.length;
+    }
+
+    /** Number of dead-lettered operations kept in {@code dead/}. */
+    public int deadSize() {
+        File[] files = new File(dir, DEAD_SUBDIR).listFiles((d, name) -> name.endsWith(SUFFIX));
+        return files == null ? 0 : files.length;
+    }
+
+    /** Cumulative count of successfully sent (removed) operations since start. */
+    public long sentCount() {
+        return sent.get();
+    }
+
+    /** Cumulative count of operations moved to dead-letter since start. */
+    public long deadLetterCount() {
+        return deadLettered.get();
     }
 
     public synchronized List<Stored> loadAll() {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
@@ -6,12 +6,18 @@ import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
 import com.payneteasy.telegram.bot.client.model.Message;
 import com.payneteasy.telegram.bot.client.model.ParseMode;
 import com.payneteasy.telegram.bot.client.model.TelegramMessage;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
+import java.io.File;
+import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -25,8 +31,16 @@ import static org.mockito.Mockito.when;
 
 public class TelegramClientTest {
 
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
     private final ITelegramService service = mock(ITelegramService.class);
-    private final TelegramClient   client  = new TelegramClient(service, 0L); // no pacing delay in tests
+    private TelegramClient         client;
+
+    @Before
+    public void setUp() throws Exception {
+        client = new TelegramClient(service, 0L, tmp.newFolder("main")); // no pacing delay in tests
+    }
 
     @Test
     public void sendMessageReturnsMessageId() {
@@ -54,24 +68,42 @@ public class TelegramClientTest {
         when(service.editMessageText(any())).thenAnswer(invocation -> {
             if (calls.getAndIncrement() == 0) {
                 entered.countDown();
-                release.await(); // hold the worker inside the first edit
+                release.await();
             }
             return null;
         });
 
-        client.editMessage(1L, 10L, "t0", null);       // schedules the first flush
-        assertTrue(entered.await(2, SECONDS));           // worker is now blocked in the first editMessageText
+        client.editMessage(1L, 10L, "t0", null);
+        assertTrue(entered.await(2, SECONDS));
 
         for (int i = 1; i <= 20; i++) {
-            client.editMessage(1L, 10L, "t" + i, null);  // coalesce into a single follow-up flush
+            client.editMessage(1L, 10L, "t" + i, null);
         }
         release.countDown();
 
-        // exactly 2 calls: the in-flight one + one coalesced carrying the latest text
         ArgumentCaptor<EditMessageTextRequest> captor = ArgumentCaptor.forClass(EditMessageTextRequest.class);
         verify(service, timeout(2000).times(2)).editMessageText(captor.capture());
         verify(service, after(300).times(2)).editMessageText(any());
         assertEquals("t20", captor.getAllValues().get(1).getText());
+    }
+
+    @Test
+    public void resendsPersistedOperationsOnStartup() throws Exception {
+        File dir = tmp.newFolder("replay");
+        // a SEND that was persisted but not confirmed sent before a restart
+        Files.write(new File(dir, "00000000000000000001.json").toPath(),
+                "{\"kind\":\"SEND\",\"chatId\":42,\"text\":\"pending\",\"parseMode\":\"HTML\"}".getBytes(UTF_8));
+
+        TelegramMessage sent = message(999L);
+        when(service.sendMessage(any())).thenReturn(sent);
+
+        // constructing the client replays the spool and resends
+        new TelegramClient(service, 0L, dir);
+
+        verify(service, timeout(2000)).sendMessage(any());
+        // successfully sent -> spool file removed
+        Thread.sleep(200);
+        assertEquals(0, dir.listFiles((d, n) -> n.endsWith(".json")).length);
     }
 
     private static TelegramMessage message(long aId) {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.mock;
@@ -104,6 +105,25 @@ public class TelegramClientTest {
         // successfully sent -> spool file removed
         Thread.sleep(200);
         assertEquals(0, dir.listFiles((d, n) -> n.endsWith(".json")).length);
+    }
+
+    @Test
+    public void deadLettersSendAfterMaxAttempts() throws Exception {
+        File dir = tmp.newFolder("dead-letter");
+        // always 429 with retry_after=0 -> retries are immediate (no real backoff), fast test
+        when(service.sendMessage(any())).thenThrow(new TelegramCommandException("Too Many Requests", "1", 429, 0));
+
+        TelegramClient failing = new TelegramClient(service, 0L, dir);
+        try {
+            failing.sendMessage(1L, "boom", null);
+            fail("expected failure after max attempts");
+        } catch (RuntimeException expected) {
+            // ok — gave up after MAX_ATTEMPTS
+        }
+
+        verify(service, times(10)).sendMessage(any()); // Backoff.MAX_ATTEMPTS
+        assertEquals(0, dir.listFiles((d, n) -> n.endsWith(".json")).length);       // removed from active spool
+        assertEquals(1, new File(dir, "dead").listFiles((d, n) -> n.endsWith(".json")).length); // moved to dead-letter
     }
 
     private static TelegramMessage message(long aId) {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -59,6 +60,18 @@ public class TelegramClientTest {
 
         assertEquals(7L, client.sendMessage(1L, "hi", null));
         verify(service, times(2)).sendMessage(any());
+    }
+
+    @Test
+    public void recordsSendLatencyOnSuccess() throws Exception {
+        AtomicLong recorded = new AtomicLong(-1);
+        TelegramClient timed = new TelegramClient(service, 0L, tmp.newFolder("latency"), recorded::set);
+
+        TelegramMessage sent = message(1L);
+        when(service.sendMessage(any())).thenReturn(sent);
+
+        timed.sendMessage(1L, "hi", ParseMode.HTML);
+        assertTrue("latency should be recorded and positive", recorded.get() > 0);
     }
 
     @Test

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpoolTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpoolTest.java
@@ -5,9 +5,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PersistentSpoolTest {
 
@@ -38,6 +40,17 @@ public class PersistentSpoolTest {
         List<Stored> all = spool.loadAll();
         assertEquals(1, all.size());
         assertEquals("{\"t\":\"b\"}", all.get(0).getJson());
+    }
+
+    @Test
+    public void deadLetterMovesFileToDeadSubdir() {
+        PersistentSpool spool = new PersistentSpool(tmp.getRoot());
+        String file = spool.append("{\"a\":1}");
+
+        spool.deadLetter(file);
+
+        assertEquals(0, spool.loadAll().size());
+        assertTrue(new File(new File(tmp.getRoot(), "dead"), file).exists());
     }
 
     @Test

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpoolTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpoolTest.java
@@ -1,0 +1,57 @@
+package io.pne.deploy.client.redmine.remote.queue;
+
+import io.pne.deploy.client.redmine.remote.queue.PersistentSpool.Stored;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PersistentSpoolTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void appendKeepsFifoOrderAndRemoveDrops() {
+        PersistentSpool spool = new PersistentSpool(tmp.getRoot());
+        String first  = spool.append("{\"a\":1}");
+        spool.append("{\"a\":2}");
+
+        List<Stored> all = spool.loadAll();
+        assertEquals(2, all.size());
+        assertEquals("{\"a\":1}", all.get(0).getJson());
+        assertEquals("{\"a\":2}", all.get(1).getJson());
+
+        spool.remove(first);
+        assertEquals(1, spool.loadAll().size());
+    }
+
+    @Test
+    public void putOverwritesByKey() {
+        PersistentSpool spool = new PersistentSpool(tmp.getRoot());
+        spool.put("edit-1-100", "{\"t\":\"a\"}");
+        spool.put("edit-1-100", "{\"t\":\"b\"}");
+
+        List<Stored> all = spool.loadAll();
+        assertEquals(1, all.size());
+        assertEquals("{\"t\":\"b\"}", all.get(0).getJson());
+    }
+
+    @Test
+    public void reopenSeesPendingAndContinuesSequence() {
+        PersistentSpool first = new PersistentSpool(tmp.getRoot());
+        first.append("{\"a\":1}");
+
+        PersistentSpool reopened = new PersistentSpool(tmp.getRoot());
+        assertEquals(1, reopened.loadAll().size());
+        reopened.append("{\"a\":2}");
+
+        List<Stored> all = reopened.loadAll();
+        assertEquals(2, all.size());
+        assertEquals("{\"a\":1}", all.get(0).getJson());
+        assertEquals("{\"a\":2}", all.get(1).getJson());
+    }
+}

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpoolTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/queue/PersistentSpoolTest.java
@@ -54,6 +54,23 @@ public class PersistentSpoolTest {
     }
 
     @Test
+    public void tracksSizeSentAndDeadLetterCounts() {
+        PersistentSpool spool = new PersistentSpool(tmp.getRoot());
+        String first  = spool.append("{\"x\":1}");
+        String second = spool.append("{\"x\":2}");
+        assertEquals(2, spool.size());
+
+        spool.remove(first);
+        assertEquals(1, spool.size());
+        assertEquals(1, spool.sentCount());
+
+        spool.deadLetter(second);
+        assertEquals(0, spool.size());
+        assertEquals(1, spool.deadSize());
+        assertEquals(1, spool.deadLetterCount());
+    }
+
+    @Test
     public void reopenSeesPendingAndContinuesSequence() {
         PersistentSpool first = new PersistentSpool(tmp.getRoot());
         first.append("{\"a\":1}");

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,12 @@
                 <version>1.0-8</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-registry-prometheus</artifactId>
+                <version>1.12.6</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/server-vertx/pom.xml
+++ b/server-vertx/pom.xml
@@ -59,6 +59,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
         </dependency>

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -21,6 +21,14 @@ import io.pne.deploy.server.vertx.status.TaskExecutionListenerQueue;
 import io.pne.deploy.server.vertx.status.TaskExecutionListenerStatus;
 import io.pne.deploy.server.vertx.status.TaskExecutionListenerTelegram;
 import io.pne.deploy.server.vertx.status.model.TaskStatus;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.pne.deploy.server.vertx.metrics.MetricsHttpHandler;
+import io.pne.deploy.server.vertx.metrics.QueueMetrics;
 import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +86,7 @@ public class VertxServerApplication {
 
         ArrayBlockingQueue<Long>     pendingIssues = new ArrayBlockingQueue<>(1000);
 
-        this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, event -> {});
+        this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, event -> {}, event -> {});
         this.serverListener = serverListener;
     }
 
@@ -89,7 +97,7 @@ public class VertxServerApplication {
         CommandResponses          response          = new CommandResponses();
         ArrayBlockingQueue<Long>  pendingIssues     = new ArrayBlockingQueue<>(1000);
         IRedmineRemoteConfig      redmineConfig     = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
-        IRemoteRedmineService     redmine           = new RemoteRedmine4_2_10ServiceImpl(redmineConfig);
+        RemoteRedmine4_2_10ServiceImpl redmine      = new RemoteRedmine4_2_10ServiceImpl(redmineConfig);
         IVertxServerConfiguration config            = StartupParametersFactory.getStartupParameters(IVertxServerConfiguration.class);
         StatusHttpHandler         statusHttpHandler = new StatusHttpHandler(agentConnections, pendingIssues);
         // Single Telegram client shared by both the live-status listener and the diff notifications,
@@ -98,6 +106,16 @@ public class VertxServerApplication {
         IRemoteTelegramService    diffTelegram      = new RemoteTelegramServiceImpl(telegramClient, redmineConfig);
         ITaskExecutionListener    taskListener      = createTaskListener(statusHttpHandler, redmineConfig, telegramClient);
 
+        // Prometheus metrics for both durable queues (scraped at /metrics)
+        PrometheusMeterRegistry   metrics           = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        QueueMetrics.register(metrics, "telegram", telegramClient.getSpool());
+        QueueMetrics.register(metrics, "redmine", redmine.getSpool());
+        new JvmMemoryMetrics().bindTo(metrics);
+        new JvmGcMetrics().bindTo(metrics);
+        new JvmThreadMetrics().bindTo(metrics);
+        new ProcessorMetrics().bindTo(metrics);
+        MetricsHttpHandler        metricsHttpHandler = new MetricsHttpHandler(metrics);
+
         deployService       = new DeployServiceImpl(new VertxAgentFinderServiceImpl(agentConnections, gson, response, taskListener), config.getAliasesDir(), taskListener);
 
         RedmineIssuesProcessServiceImpl redmineIssuesProcessService = new RedmineIssuesProcessServiceImpl(redmine, deployService, redmineConfig, diffTelegram);
@@ -105,7 +123,7 @@ public class VertxServerApplication {
 
         this.vertx          = Vertx.vertx();
 
-        this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler);
+        this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler);
         this.serverListener = serverListener;
     }
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import java.io.File;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -93,7 +94,7 @@ public class VertxServerApplication {
         StatusHttpHandler         statusHttpHandler = new StatusHttpHandler(agentConnections, pendingIssues);
         // Single Telegram client shared by both the live-status listener and the diff notifications,
         // so all traffic goes through one rate-limited queue (one limit per chat).
-        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.getTelegramToken());
+        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.getTelegramToken(), new File(redmineConfig.queueDir(), "telegram"));
         IRemoteTelegramService    diffTelegram      = new RemoteTelegramServiceImpl(telegramClient, redmineConfig);
         ITaskExecutionListener    taskListener      = createTaskListener(statusHttpHandler, redmineConfig, telegramClient);
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 
 public class VertxServerApplication {
 
@@ -97,17 +98,21 @@ public class VertxServerApplication {
         CommandResponses          response          = new CommandResponses();
         ArrayBlockingQueue<Long>  pendingIssues     = new ArrayBlockingQueue<>(1000);
         IRedmineRemoteConfig      redmineConfig     = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
-        RemoteRedmine4_2_10ServiceImpl redmine      = new RemoteRedmine4_2_10ServiceImpl(redmineConfig);
+
+        // Prometheus metrics for both durable queues (scraped at /metrics); recorders must exist before the queues.
+        PrometheusMeterRegistry   metrics           = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        LongConsumer              telegramLatency   = QueueMetrics.sendLatencyRecorder(metrics, "telegram");
+        LongConsumer              redmineLatency    = QueueMetrics.sendLatencyRecorder(metrics, "redmine");
+
+        RemoteRedmine4_2_10ServiceImpl redmine      = new RemoteRedmine4_2_10ServiceImpl(redmineConfig, redmineLatency);
         IVertxServerConfiguration config            = StartupParametersFactory.getStartupParameters(IVertxServerConfiguration.class);
         StatusHttpHandler         statusHttpHandler = new StatusHttpHandler(agentConnections, pendingIssues);
         // Single Telegram client shared by both the live-status listener and the diff notifications,
         // so all traffic goes through one rate-limited queue (one limit per chat).
-        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.getTelegramToken(), new File(redmineConfig.queueDir(), "telegram"));
+        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.getTelegramToken(), new File(redmineConfig.queueDir(), "telegram"), telegramLatency);
         IRemoteTelegramService    diffTelegram      = new RemoteTelegramServiceImpl(telegramClient, redmineConfig);
         ITaskExecutionListener    taskListener      = createTaskListener(statusHttpHandler, redmineConfig, telegramClient);
 
-        // Prometheus metrics for both durable queues (scraped at /metrics)
-        PrometheusMeterRegistry   metrics           = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         QueueMetrics.register(metrics, "telegram", telegramClient.getSpool());
         QueueMetrics.register(metrics, "redmine", redmine.getSpool());
         new JvmMemoryMetrics().bindTo(metrics);

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
@@ -29,6 +29,7 @@ public class WebSocketVerticle extends AbstractVerticle {
     private final IRedmineRemoteConfig        redmineConfig;
     private final Collection<Long>            issues;
     private final Handler<HttpServerRequest>           statusHttpHandler;
+    private final Handler<HttpServerRequest>           metricsHttpHandler;
 
     public WebSocketVerticle(int aPort
             , IServerApplicationListener aServerListener
@@ -41,6 +42,7 @@ public class WebSocketVerticle extends AbstractVerticle {
             , Collection<Long>  aIssues
             , ITaskExecutionListener aListener
             , Handler<HttpServerRequest> aStatusHttpHandler
+            , Handler<HttpServerRequest> aMetricsHttpHandler
     ) {
         this.serverWebSocketFrameHandler = new ServerWebSocketFrameHandler(aServerListener, aGson, aCommandResponses, aListener);
         port = aPort;
@@ -50,6 +52,7 @@ public class WebSocketVerticle extends AbstractVerticle {
         redmineConfig = aRedmineConfig;
         issues = aIssues;
         statusHttpHandler = aStatusHttpHandler;
+        metricsHttpHandler = aMetricsHttpHandler;
     }
 
     @Override
@@ -91,7 +94,7 @@ public class WebSocketVerticle extends AbstractVerticle {
 //                    aSocket.writeBinaryMessage(buffer);
 
                 })
-                .requestHandler(new HttpHandler(connections, deployService, commandExecutor, redmineConfig, issues, statusHttpHandler))
+                .requestHandler(new HttpHandler(connections, deployService, commandExecutor, redmineConfig, issues, statusHttpHandler, metricsHttpHandler))
                 .listen(port, "127.0.0.1", event -> {
                     if(event.failed()) {
                         aStartFuture.fail(event.cause());

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/http/HttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/http/HttpHandler.java
@@ -25,6 +25,7 @@ public class HttpHandler implements Handler<HttpServerRequest> {
     private final RedmineCallbackHttpHander redmineCallbackHttpHander;
     private final Collection<Long>  issues;
     private final Handler<HttpServerRequest> statusHttpHandler;
+    private final Handler<HttpServerRequest> metricsHttpHandler;
 
     public HttpHandler(
             AgentConnections connections
@@ -33,6 +34,7 @@ public class HttpHandler implements Handler<HttpServerRequest> {
             , IRedmineRemoteConfig aRedmineConfig
             , Collection<Long> aIssues
             , Handler<HttpServerRequest> aStatusHandler
+            , Handler<HttpServerRequest> aMetricsHandler
     ) {
         this.connections = connections;
         this.deployService = deployService;
@@ -41,6 +43,7 @@ public class HttpHandler implements Handler<HttpServerRequest> {
         redmineCallbackHttpHander = new RedmineCallbackHttpHander(aIssues);
         issues = aIssues;
         statusHttpHandler = aStatusHandler;
+        metricsHttpHandler = aMetricsHandler;
     }
 
     @Override
@@ -55,6 +58,11 @@ public class HttpHandler implements Handler<HttpServerRequest> {
 
         if(aRequest.uri().startsWith(redmineConfig.statusPageHtmlPath())) {
             statusHttpHandler.handle(aRequest);
+            return;
+        }
+
+        if("/metrics".equals(aRequest.uri())) {
+            metricsHttpHandler.handle(aRequest);
             return;
         }
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/MetricsHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/MetricsHttpHandler.java
@@ -1,0 +1,22 @@
+package io.pne.deploy.server.vertx.metrics;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+
+/** Serves the Prometheus text exposition on {@code /metrics}. */
+public class MetricsHttpHandler implements Handler<HttpServerRequest> {
+
+    private final PrometheusMeterRegistry registry;
+
+    public MetricsHttpHandler(PrometheusMeterRegistry aRegistry) {
+        this.registry = aRegistry;
+    }
+
+    @Override
+    public void handle(HttpServerRequest aRequest) {
+        aRequest.response()
+                .putHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                .end(registry.scrape());
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/QueueMetrics.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/QueueMetrics.java
@@ -1,0 +1,35 @@
+package io.pne.deploy.server.vertx.metrics;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+
+/** Registers Prometheus metrics for a durable queue's spool: pending/dead gauges + sent/dead-lettered counters. */
+public final class QueueMetrics {
+
+    private QueueMetrics() {
+    }
+
+    public static void register(MeterRegistry aRegistry, String aQueue, PersistentSpool aSpool) {
+        Gauge.builder("deploy_queue_pending", aSpool, PersistentSpool::size)
+                .description("Pending (not yet sent) operations spooled")
+                .tag("queue", aQueue)
+                .register(aRegistry);
+
+        Gauge.builder("deploy_queue_dead", aSpool, PersistentSpool::deadSize)
+                .description("Operations currently in the dead-letter directory")
+                .tag("queue", aQueue)
+                .register(aRegistry);
+
+        FunctionCounter.builder("deploy_queue_sent_total", aSpool, PersistentSpool::sentCount)
+                .description("Operations successfully sent since start")
+                .tag("queue", aQueue)
+                .register(aRegistry);
+
+        FunctionCounter.builder("deploy_queue_deadlettered_total", aSpool, PersistentSpool::deadLetterCount)
+                .description("Operations dead-lettered since start")
+                .tag("queue", aQueue)
+                .register(aRegistry);
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/QueueMetrics.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/QueueMetrics.java
@@ -3,7 +3,11 @@ package io.pne.deploy.server.vertx.metrics;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongConsumer;
 
 /** Registers Prometheus metrics for a durable queue's spool: pending/dead gauges + sent/dead-lettered counters. */
 public final class QueueMetrics {
@@ -31,5 +35,18 @@ public final class QueueMetrics {
                 .description("Operations dead-lettered since start")
                 .tag("queue", aQueue)
                 .register(aRegistry);
+    }
+
+    /**
+     * Creates a latency histogram for a queue and returns a recorder to feed it (nanoseconds per successful call).
+     * The returned {@link LongConsumer} can be passed straight into the queue constructors.
+     */
+    public static LongConsumer sendLatencyRecorder(MeterRegistry aRegistry, String aQueue) {
+        Timer timer = Timer.builder("deploy_queue_send_latency")
+                .description("Latency of a successful send/edit call to the external service")
+                .publishPercentileHistogram()
+                .tag("queue", aQueue)
+                .register(aRegistry);
+        return nanos -> timer.record(nanos, TimeUnit.NANOSECONDS);
     }
 }

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/metrics/QueueMetricsTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/metrics/QueueMetricsTest.java
@@ -1,0 +1,35 @@
+package io.pne.deploy.server.vertx.metrics;
+
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QueueMetricsTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void exposesQueueMetricsInScrape() {
+        PersistentSpool spool = new PersistentSpool(tmp.getRoot());
+        String first = spool.append("{\"x\":1}");
+        spool.append("{\"x\":2}");
+        spool.remove(first); // 1 pending, sent=1
+
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        QueueMetrics.register(registry, "redmine", spool);
+
+        assertEquals(1.0, registry.get("deploy_queue_pending").tag("queue", "redmine").gauge().value(), 0.0);
+        assertEquals(1.0, registry.get("deploy_queue_sent_total").tag("queue", "redmine").functionCounter().count(), 0.0);
+
+        String scrape = registry.scrape();
+        assertTrue(scrape.contains("deploy_queue_pending"));
+        assertTrue(scrape.contains("deploy_queue_sent_total"));
+    }
+}

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/metrics/QueueMetricsTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/metrics/QueueMetricsTest.java
@@ -7,6 +7,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.util.function.LongConsumer;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -31,5 +33,16 @@ public class QueueMetricsTest {
         String scrape = registry.scrape();
         assertTrue(scrape.contains("deploy_queue_pending"));
         assertTrue(scrape.contains("deploy_queue_sent_total"));
+    }
+
+    @Test
+    public void exposesSendLatencyHistogram() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        LongConsumer recorder = QueueMetrics.sendLatencyRecorder(registry, "telegram");
+
+        recorder.accept(5_000_000L); // 5 ms
+
+        assertEquals(1L, registry.get("deploy_queue_send_latency").tag("queue", "telegram").timer().count());
+        assertTrue(registry.scrape().contains("deploy_queue_send_latency_seconds_bucket"));
     }
 }


### PR DESCRIPTION
## Что и зачем

Делаем очереди Telegram и Redmine **надёжными и наблюдаемыми**: durable-спул на диск + replay при старте, dead-letter для «poison»-операций, и Prometheus-метрики на `/metrics`.

Семантика доставки — **at-least-once**; область — очереди сообщений (Telegram + Redmine-мутации); diff-вычисление не персистится.

## Коммиты
1. **PersistentSpool + QUEUE_DIR** — примитив долговечности (`append`/`put`/`remove`/`loadAll`/`deadLetter` + счётчики), параметр `QUEUE_DIR=./queue`.
2. **redmine: persist + replay** — мутации Redmine как `RedmineOp`, спул `queue/redmine`, replay в конструкторе.
3. **telegram: persist + replay** — `TelegramOp` (SEND sequential, EDIT keyed/coalesce), спул `queue/telegram`, replay.
4. **dead-letter after 10 attempts** — `Backoff` (10 попыток, экспоненциальный c потолком 60s; 429 → `retry_after`); после исчерпания операция уходит в `queue/<q>/dead`.
5. **Prometheus /metrics** — эндпоинт на том же Vert.x-сервере (bind остаётся `127.0.0.1`, скрейп локально). Метрики на очередь (`queue="telegram|redmine"`):
   - `deploy_queue_pending` (gauge) — pending в спуле;
   - `deploy_queue_dead` (gauge) — в dead-letter;
   - `deploy_queue_sent_total` (counter) — успешно отправлено;
   - `deploy_queue_deadlettered_total` (counter) — ушло в dead-letter.
   Плюс базовые JVM-биндеры (memory/gc/threads/cpu). Библиотека `micrometer-registry-prometheus` 1.12.6, эндпоинт через `MetricsHttpHandler` в существующем `HttpHandler`.

## Проверка
`mvn -B -ntp verify` под JDK 21 — `BUILD SUCCESS`; зелёные `PersistentSpoolTest`, `TelegramClientTest`, `QueueMetricsTest`, `TelegramMessagesStoreTest`, `DiffServiceProcessDiffTest`, `VertxAndWebsocketTest`. Вручную: `curl 127.0.0.1:<port>/metrics` → Prometheus-текст с `deploy_queue_*`.

## Оговорки / вне объёма
- At-least-once (редкий дубль при краше между send и удалением файла); попытки dead-letter считаются на прогон.
- Bind `/metrics` — `127.0.0.1` (скрейп локально/через туннель); открытие наружу/отдельный порт — вне объёма.
- Персист diff-вычисления, exactly-once/дедуп, ретеншн `dead/`, полная vertx-micrometer интеграция — вне объёма.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
