### PR TITLE
test(integration-test): one-class env with server, 2 agents and mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ environment variables (defaults in parentheses):
 | `TELEGRAM_ENABLED` | `false` | Enable Telegram notifications. |
 | `TELEGRAM_CHAT_ID` | `0` | Target Telegram chat id. |
 | `TELEGRAM_TOKEN` | `""` | Telegram bot token (**secret**). |
+| `TELEGRAM_URL` | `https://api.telegram.org/bot` | Telegram Bot API base URL (override for a proxy or a mock). |
 
 ## Running an agent
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/IRedmineRemoteConfig.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/IRedmineRemoteConfig.java
@@ -56,4 +56,7 @@ public interface IRedmineRemoteConfig extends IStartupConfig {
     @AStartupParameter(name = "TELEGRAM_TOKEN", value = "", maskVariable = true)
     String getTelegramToken();
 
+    @AStartupParameter(name = "TELEGRAM_URL", value = "https://api.telegram.org/bot")
+    String telegramUrl();
+
 }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteTelegramServiceImpl.java
@@ -13,7 +13,7 @@ public class RemoteTelegramServiceImpl implements IRemoteTelegramService {
     private final TelegramClient telegram;
 
     public RemoteTelegramServiceImpl(IRedmineRemoteConfig aConfig) {
-        this(new TelegramClient(aConfig.getTelegramToken(), new File(aConfig.queueDir(), "telegram")), aConfig);
+        this(new TelegramClient(aConfig.telegramUrl(), aConfig.getTelegramToken(), new File(aConfig.queueDir(), "telegram"), null), aConfig);
     }
 
     public RemoteTelegramServiceImpl(TelegramClient aTelegram, IRedmineRemoteConfig aConfig) {

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.payneteasy.telegram.bot.client.ITelegramService;
 import com.payneteasy.telegram.bot.client.TelegramCommandException;
+import com.payneteasy.telegram.bot.client.http.HttpClientTimeouts;
 import com.payneteasy.telegram.bot.client.http.TelegramHttpClientImpl;
 import com.payneteasy.telegram.bot.client.impl.TelegramServiceImpl;
 import com.payneteasy.telegram.bot.client.messages.EditMessageTextRequest;
@@ -52,6 +53,14 @@ public class TelegramClient {
 
     public TelegramClient(String aToken, File aSpoolDir, LongConsumer aSendLatencyNanos) {
         this(new TelegramServiceImpl(new TelegramHttpClientImpl(aToken)), DEFAULT_MIN_INTERVAL_MS, aSpoolDir, aSendLatencyNanos);
+    }
+
+    /** Same as above but with a configurable Telegram API base URL (e.g. a proxy or a mock server). */
+    public TelegramClient(String aBaseUrl, String aToken, File aSpoolDir, LongConsumer aSendLatencyNanos) {
+        this(new TelegramServiceImpl(new TelegramHttpClientImpl(
+                        aBaseUrl, aToken, new HttpClientTimeouts(30_000, 30_000, 30_000),
+                        new GsonBuilder().setPrettyPrinting().create())),
+                DEFAULT_MIN_INTERVAL_MS, aSpoolDir, aSendLatencyNanos);
     }
 
     public TelegramClient(ITelegramService aTelegram, long aMinIntervalMs, File aSpoolDir) {

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -97,4 +97,45 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Run the whole local environment (deploy-server + 2 agents + Redmine/GitLab/Telegram mocks)
+             from Maven in one command (Ctrl-C to stop):
+                 mvn -pl integration-test -am -Prun-env process-test-classes
+             Or just run io.pne.deploy.tests.env.LocalEnvironment#main from the IDE. -->
+        <profile>
+            <id>run-env</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>run-local-environment</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <!-- Fork a JVM (like the fat jars) with the Gson add-opens so error responses
+                             serialize cleanly, and run the harness on the test classpath. -->
+                        <configuration>
+                            <executable>java</executable>
+                            <classpathScope>test</classpathScope>
+                            <arguments>
+                                <argument>--add-opens</argument>
+                                <argument>java.base/java.lang=ALL-UNNAMED</argument>
+                                <argument>-classpath</argument>
+                                <classpath/>
+                                <argument>io.pne.deploy.tests.env.LocalEnvironment</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
@@ -1,0 +1,30 @@
+package io.pne.deploy.tests;
+
+import io.pne.deploy.tests.env.LocalEnvironment;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * End-to-end smoke test of the whole environment: boots the deploy-server, two websocket agents, and
+ * Redmine/GitLab/Telegram HTTP mocks, then drives one Redmine issue through the full pipeline and
+ * asserts every external system was exercised.
+ */
+public class FullEnvironmentTest {
+
+    @Test
+    public void deploysAnIssueThroughTheWholeEnvironment() throws Exception {
+        try (LocalEnvironment env = new LocalEnvironment()) {
+            env.start();
+            env.triggerIssue(1001);
+
+            // A DONE status PUT only happens after validation → Processing → runTask on BOTH agents → Done.
+            assertTrue("Redmine should receive the DONE status update (whole chain succeeded)",
+                    env.redmine().await(r -> "PUT".equals(r.method) && r.body.contains("Task is DONE"), 25_000));
+            assertTrue("GitLab compare (diff) should be requested",
+                    env.gitlab().await(r -> "GET".equals(r.method) && r.path.contains("/repository/compare"), 25_000));
+            assertTrue("Telegram sendMessage should be delivered",
+                    env.telegram().await(r -> "POST".equals(r.method) && r.path.contains("/sendMessage"), 25_000));
+        }
+    }
+}

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/HttpMock.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/HttpMock.java
@@ -1,0 +1,132 @@
+package io.pne.deploy.tests.env;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * A tiny recording HTTP mock backed by a raw Vert.x {@link HttpServer}. Every request (method, path,
+ * query, body) is recorded; the supplied {@link Responder} writes the reply. Used to stand in for
+ * Redmine / GitLab / Telegram in the local integration environment.
+ */
+public class HttpMock {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpMock.class);
+
+    /** Writes the response for a received request (body already fully read). */
+    public interface Responder {
+        void respond(HttpServerRequest request, String body);
+    }
+
+    /** One recorded request. */
+    public static final class Rec {
+        public final String method;
+        public final String path;
+        public final String query;
+        public final String body;
+
+        Rec(String aMethod, String aPath, String aQuery, String aBody) {
+            method = aMethod;
+            path   = aPath;
+            query  = aQuery;
+            body   = aBody;
+        }
+
+        @Override
+        public String toString() {
+            return method + " " + path + (query == null ? "" : "?" + query);
+        }
+    }
+
+    private final String       name;
+    private final int          port;
+    private final HttpServer    server;
+    private final List<Rec>    received = Collections.synchronizedList(new ArrayList<>());
+
+    public HttpMock(Vertx aVertx, String aName, int aPort, Responder aResponder) {
+        this.name = aName;
+        this.port = aPort;
+        CountDownLatch started = new CountDownLatch(1);
+        this.server = aVertx.createHttpServer()
+                .requestHandler(request -> request.bodyHandler(buffer -> {
+                    String body = buffer.toString();
+                    received.add(new Rec(request.method().name(), request.path(), request.query(), body));
+                    LOG.debug("[{}] {} {}", name, request.method(), request.uri());
+                    try {
+                        aResponder.respond(request, body);
+                    } catch (RuntimeException e) {
+                        LOG.error("[{}] responder failed", name, e);
+                        if (!request.response().ended()) {
+                            request.response().setStatusCode(500).end(e.toString());
+                        }
+                    }
+                }))
+                .listen(port, "127.0.0.1", ar -> started.countDown());
+        awaitLatch(started);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public List<Rec> received() {
+        synchronized (received) {
+            return new ArrayList<>(received);
+        }
+    }
+
+    /** Polls the recorded requests until one matches {@code predicate} or the timeout elapses. */
+    public boolean await(Predicate<Rec> aPredicate, long aTimeoutMs) {
+        long deadline = System.currentTimeMillis() + aTimeoutMs;
+        do {
+            if (matches(aPredicate)) {
+                return true;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        } while (System.currentTimeMillis() < deadline);
+        return matches(aPredicate);
+    }
+
+    private boolean matches(Predicate<Rec> aPredicate) {
+        synchronized (received) {
+            for (Rec rec : received) {
+                if (aPredicate.test(rec)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public void stop() {
+        CountDownLatch done = new CountDownLatch(1);
+        server.close(ar -> done.countDown());
+        awaitLatch(done);
+    }
+
+    private static void awaitLatch(CountDownLatch aLatch) {
+        try {
+            aLatch.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
@@ -1,0 +1,356 @@
+package io.pne.deploy.tests.env;
+
+import io.pne.deploy.agent.websocket.WebSocketAgentApplication;
+import io.pne.deploy.server.vertx.VertxServerApplication;
+import io.pne.deploy.tests.TestAgentApplicationListener;
+import io.pne.deploy.tests.TestAgentStartupParameters;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Boots the ENTIRE deploy environment in one process — the deploy-server, two websocket deploy-agents,
+ * and HTTP mocks for Redmine, GitLab and Telegram — wired together via system properties (which the
+ * {@code @AStartupParameter} config layer reads before environment variables). Runnable from a
+ * {@link #main(String[])} (IntelliJ, or {@code mvn exec:java}) and reusable from tests.
+ *
+ * <p>The mocks are just enough to drive one Redmine issue through the full pipeline:
+ * getIssue → Nashorn validation → GitLab diff → deploy on both agents → Redmine status updates +
+ * Telegram notifications.
+ */
+public class LocalEnvironment implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalEnvironment.class);
+
+    private static final String TOKEN        = "test-token";
+    private static final String ALIAS        = "deploy-demo";
+    private static final String CALLBACK_URI = "/redmine/callback";
+    // The line the pipeline looks for in the issue description (alias-line chars are restricted: no '/', ':', '=').
+    private static final String DEPLOY_LINE = "> deploy " + ALIAS;
+
+    private final int serverPort   = Ports.free();
+    private final int redminePort  = Ports.free();
+    private final int gitlabPort   = Ports.free();
+    private final int telegramPort = Ports.free();
+
+    private final Vertx mockVertx = Vertx.vertx();
+
+    private final List<String> setProps = new ArrayList<>();
+
+    private HttpMock redmine;
+    private HttpMock gitlab;
+    private HttpMock telegram;
+
+    private VertxServerApplication server;
+
+    private final List<WebSocketAgentApplication> agents    = new ArrayList<>();
+    private final List<ExecutorService>           executors = new ArrayList<>();
+
+    private Path aliasesDir;
+    private Path queueDir;
+    private Path validationScript;
+
+    public void start() throws Exception {
+        LOG.info("Starting local environment: server={} redmine={} gitlab={} telegram={}",
+                serverPort, redminePort, gitlabPort, telegramPort);
+
+        startMocks();
+        writeTempFiles();
+        applySystemProperties();
+
+        server = new VertxServerApplication();
+        server.start();
+        waitForServer();
+
+        startAgent("agent-1");
+        startAgent("agent-2");
+
+        LOG.info("Local environment is up.");
+    }
+
+    private void startMocks() {
+        redmine = new HttpMock(mockVertx, "redmine", redminePort, (req, body) -> {
+            String path = req.path();
+            if (req.method() == HttpMethod.GET && path.matches("/issues/\\d+\\.json")) {
+                String id = path.replaceAll("\\D", "");
+                req.response().putHeader("Content-Type", "application/json").end(issueJson(id));
+            } else if (req.method() == HttpMethod.PUT && path.matches("/issues/\\d+\\.json")) {
+                req.response().setStatusCode(204).end();
+            } else {
+                req.response().setStatusCode(404).end("not found\n");
+            }
+        });
+
+        gitlab = new HttpMock(mockVertx, "gitlab", gitlabPort, (req, body) -> {
+            String path = req.path();
+            if (path.equals("/old-version")) {
+                req.response().end("1.2.2\n"); // first line = old version
+            } else if (path.contains("/repository/compare")) {
+                req.response().putHeader("Content-Type", "application/json")
+                        .end("{\"commits\":[{\"message\":\"deploy demo build\"}]}");
+            } else {
+                req.response().setStatusCode(404).end("not found\n");
+            }
+        });
+
+        telegram = new HttpMock(mockVertx, "telegram", telegramPort, (req, body) ->
+                req.response().putHeader("Content-Type", "application/json")
+                        .end("{\"ok\":true,\"result\":{\"message_id\":1}}"));
+    }
+
+    private static String issueJson(String aId) {
+        return "{\"issue\":{"
+                + "\"id\":" + aId + ","
+                + "\"subject\":\"demo deploy\","
+                + "\"description\":\"" + DEPLOY_LINE + "\","
+                + "\"status\":{\"id\":2,\"name\":\"In Progress\"},"
+                + "\"project\":{\"id\":1,\"name\":\"demo\"},"
+                + "\"author\":{\"id\":1,\"name\":\"author\"},"
+                + "\"assigned_to\":{\"id\":2,\"name\":\"assignee\"},"
+                + "\"custom_fields\":[]"
+                + "}}";
+    }
+
+    private void writeTempFiles() {
+        try {
+            aliasesDir       = Files.createTempDirectory("deploy-env-aliases");
+            queueDir         = Files.createTempDirectory("deploy-env-queue");
+            validationScript = Files.createTempFile("issue-validation", ".js");
+            Files.writeString(validationScript, "true;\n", StandardCharsets.UTF_8);
+
+            String oldVersionUrl = "http://127.0.0.1:" + gitlabPort + "/old-version";
+            String yaml = ""
+                    + "commands:\n"
+                    + "- agents: agent-1\n"
+                    + "  name: echo\n"
+                    + "  arguments:\n"
+                    + "    - deployed\n"
+                    + "    - 1.2.3\n"
+                    + "    - " + oldVersionUrl + "\n"
+                    + "    - gitlab=42\n"
+                    + "- agents: agent-2\n"
+                    + "  name: echo\n"
+                    + "  arguments:\n"
+                    + "    - deployed\n"
+                    + "    - 1.2.3\n"
+                    + "    - " + oldVersionUrl + "\n"
+                    + "    - gitlab=42\n";
+            Files.writeString(aliasesDir.resolve(ALIAS + ".yml"), yaml, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("cannot write temp environment files", e);
+        }
+    }
+
+    private void applySystemProperties() {
+        set("VERTX_SERVER_PORT",       Integer.toString(serverPort));
+        set("VERTX_ALIASES_DIR",       aliasesDir.toString());
+        set("REDMINE_URL",             "http://127.0.0.1:" + redminePort);
+        set("REDMINE_API_ACCESS_KEY",  "test-key");
+        set("REDMINE_CALLBACK_URI",    CALLBACK_URI);
+        set("ISSUE_VALIDATION_SCRIPT", validationScript.toString());
+        set("QUEUE_DIR",               queueDir.toString());
+        set("GITLAB_URL",              "http://127.0.0.1:" + gitlabPort);
+        set("GITLAB_API_KEY",          "test-gitlab-key");
+        set("TELEGRAM_ENABLED",        "true");
+        set("TELEGRAM_TOKEN",          TOKEN);
+        set("TELEGRAM_CHAT_ID",        "1");
+        set("TELEGRAM_URL",            "http://127.0.0.1:" + telegramPort + "/bot");
+        set("DASHBOARD_REFRESH_MS",    "1000");
+    }
+
+    private void set(String aName, String aValue) {
+        System.setProperty(aName, aValue);
+        setProps.add(aName);
+    }
+
+    private void waitForServer() throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl() + "/deploy/status"))
+                .timeout(Duration.ofSeconds(2)).GET().build();
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() == 200) {
+                    return;
+                }
+            } catch (IOException ignored) {
+                // server not up yet
+            }
+            Thread.sleep(200);
+        }
+        throw new IllegalStateException("deploy-server did not become ready on " + baseUrl());
+    }
+
+    private void startAgent(String aAgentId) throws InterruptedException {
+        TestAgentApplicationListener listener = new TestAgentApplicationListener();
+        WebSocketAgentApplication agent = new WebSocketAgentApplication(listener,
+                new TestAgentStartupParameters(baseUrl() + "/", aAgentId));
+        ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "agent-" + aAgentId);
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.execute(agent::start);
+        agents.add(agent);
+        executors.add(executor);
+        if (!listener.waitUntilConnected(10, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("agent " + aAgentId + " did not connect");
+        }
+        LOG.info("Agent {} connected", aAgentId);
+    }
+
+    /** Enqueues a Redmine issue for processing by hitting the Redmine webhook callback with a JSON body. */
+    public void triggerIssue(long aIssueId) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder(URI.create(baseUrl() + CALLBACK_URI))
+                .timeout(Duration.ofSeconds(5))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{\"issue_id\":" + aIssueId + "}"))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        LOG.info("triggerIssue({}) -> {} {}", aIssueId, response.statusCode(), response.body().trim());
+    }
+
+    public String baseUrl() {
+        return "http://127.0.0.1:" + serverPort;
+    }
+
+    public int serverPort()   { return serverPort; }
+    public HttpMock redmine()  { return redmine; }
+    public HttpMock gitlab()   { return gitlab; }
+    public HttpMock telegram() { return telegram; }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    public void stop() {
+        for (WebSocketAgentApplication agent : agents) {
+            try {
+                agent.stop();
+            } catch (RuntimeException e) {
+                LOG.warn("agent stop failed", e);
+            }
+        }
+        for (ExecutorService executor : executors) {
+            executor.shutdownNow();
+        }
+        agents.clear();
+        executors.clear();
+
+        if (server != null) {
+            try {
+                server.stop();
+            } catch (RuntimeException e) {
+                LOG.warn("server stop failed", e);
+            }
+            server = null;
+        }
+
+        stopQuietly(redmine);
+        stopQuietly(gitlab);
+        stopQuietly(telegram);
+        redmine = gitlab = telegram = null;
+
+        CountDownLatch closed = new CountDownLatch(1);
+        mockVertx.close(ar -> closed.countDown());
+        try {
+            closed.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // Clear our system properties so they cannot leak into other tests in the same JVM.
+        for (String name : setProps) {
+            System.clearProperty(name);
+        }
+        setProps.clear();
+
+        deleteRecursively(queueDir);
+        deleteRecursively(aliasesDir);
+        deleteQuietly(validationScript);
+
+        LOG.info("Local environment stopped.");
+    }
+
+    private static void stopQuietly(HttpMock aMock) {
+        if (aMock != null) {
+            try {
+                aMock.stop();
+            } catch (RuntimeException e) {
+                LOG.warn("mock {} stop failed", aMock.name(), e);
+            }
+        }
+    }
+
+    private static void deleteRecursively(Path aDir) {
+        if (aDir == null) {
+            return;
+        }
+        try (var walk = Files.walk(aDir)) {
+            walk.sorted((a, b) -> b.getNameCount() - a.getNameCount()).forEach(LocalEnvironment::deleteQuietly);
+        } catch (IOException e) {
+            LOG.debug("cannot clean {}", aDir, e);
+        }
+    }
+
+    private static void deleteQuietly(Path aPath) {
+        if (aPath == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(aPath);
+        } catch (IOException ignored) {
+            // best effort
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        LocalEnvironment env = new LocalEnvironment();
+        Runtime.getRuntime().addShutdownHook(new Thread(env::stop, "env-shutdown"));
+        env.start();
+
+        String base = env.baseUrl();
+        System.out.println();
+        System.out.println("=========================================================");
+        System.out.println(" Deploy environment is UP");
+        System.out.println("   Server      : " + base);
+        System.out.println("   Dashboard   : " + base + "/deploy/dashboard");
+        System.out.println("   Status JSON : " + base + "/deploy/status");
+        System.out.println("   Metrics     : " + base + "/metrics");
+        System.out.println("   Agents      : agent-1, agent-2 (connected)");
+        System.out.println("   Redmine mock: http://127.0.0.1:" + env.redmine().port());
+        System.out.println("   GitLab mock : http://127.0.0.1:" + env.gitlab().port());
+        System.out.println("   Telegram mock: http://127.0.0.1:" + env.telegram().port());
+        System.out.println("   Trigger     : " + base + "/?command=issue&issue_id=1001");
+        System.out.println("=========================================================");
+        System.out.println();
+
+        env.triggerIssue(1001);
+
+        // Keep running so the dashboard can be inspected; Ctrl-C triggers the shutdown hook.
+        new CountDownLatch(1).await();
+    }
+}

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/Ports.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/Ports.java
@@ -1,0 +1,21 @@
+package io.pne.deploy.tests.env;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+
+/** Picks an ephemeral free TCP port. There is a tiny race between close and reuse, acceptable for a local harness. */
+final class Ports {
+
+    private Ports() {
+    }
+
+    static int free() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new UncheckedIOException("cannot allocate a free port", e);
+        }
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -120,7 +120,7 @@ public class VertxServerApplication {
         StatusHttpHandler         statusHttpHandler = new StatusHttpHandler(agentConnections, pendingIssues);
         // Single Telegram client shared by both the live-status listener and the diff notifications,
         // so all traffic goes through one rate-limited queue (one limit per chat).
-        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.getTelegramToken(), new File(redmineConfig.queueDir(), "telegram"), telegramLatency);
+        TelegramClient            telegramClient    = new TelegramClient(redmineConfig.telegramUrl(), redmineConfig.getTelegramToken(), new File(redmineConfig.queueDir(), "telegram"), telegramLatency);
         IRemoteTelegramService    diffTelegram      = new RemoteTelegramServiceImpl(telegramClient, redmineConfig);
         ITaskExecutionListener    taskListener      = createTaskListener(statusHttpHandler, redmineConfig, telegramClient);
 


### PR DESCRIPTION
## Что и зачем

Поднять **всю среду разработки одним классом** — deploy-server + два websocket-агента + HTTP-моки Redmine/GitLab/Telegram — и запускать её как из IntelliJ, так и через Maven, плюс автотест, гоняющий один issue сквозь весь конвейер.

## Как это работает

- `@AStartupParameter` читает **system properties → env → default**, поэтому `LocalEnvironment` выставляет `System.setProperty(...)` (URL-ы моков, порты, `TELEGRAM_ENABLED`, временные `VERTX_ALIASES_DIR`/`QUEUE_DIR`/`ISSUE_VALIDATION_SCRIPT`) и поднимает **полный** прод-стек `new VertxServerApplication()` — без рефакторинга.
- Моки — лёгкие `vertx.createHttpServer()` с записью запросов и `await(predicate, timeout)`. Redmine отдаёт issue с строкой `> deploy deploy-demo` и `204` на PUT; GitLab — `compare` + `old-version`; Telegram — `{"ok":true,...}`.
- Два реальных агента (`agent-1`, `agent-2`) подключаются по websocket и выполняют `echo`. Деплой триггерится POST-ом на Redmine-webhook.
- Единственная прод-правка: **`TELEGRAM_URL`** (в `IRedmineRemoteConfig`, дефолт `https://api.telegram.org/bot`) прокинут в `TelegramClient` → `TelegramHttpClientImpl(baseUrl, …)` — чтобы Telegram можно было направить в мок или прокси (base URL раньше был захардкожен).

## Запуск

- **IntelliJ**: запустить `io.pne.deploy.tests.env.LocalEnvironment#main` — печатает URL-ы (dashboard/status/metrics + порты моков), триггерит issue 1001, держит среду до Ctrl-C.
- **Maven**: `mvn -pl integration-test -am -Prun-env process-test-classes` (форкает JVM с `--add-opens`, как fat-jar; Ctrl-C для остановки).

## Проверка

`mvn -B -ntp verify` под JDK 21 → `BUILD SUCCESS`. `FullEnvironmentTest` поднимает среду, триггерит issue и проверяет: Redmine получил PUT со статусом DONE (значит валидация → Processing → деплой на обоих агентах → Done прошли), GitLab — запрос diff, Telegram — sendMessage. Существующие тесты зелёные; `DashboardHttpTest` после него в том же JVM тоже зелёный — system properties очищаются в teardown (нет утечки).

## Вне объёма
- Windows-специфика shell (агенты гоняют `echo`; CI — Ubuntu).
- Проверка значений метрик (дашборд доступен для ручного осмотра).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
