### PR TITLE
fix(dashboard): keep delivery-queues table inside its card

### DIFF
--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -74,9 +74,9 @@ public final class DashboardView {
             return "<p class=\"muted\">no queues</p>";
         }
         StringBuilder sb = new StringBuilder();
-        sb.append("<table><thead><tr><th>queue</th>")
+        sb.append("<div class=\"tablewrap\"><table><thead><tr><th>queue</th>")
           .append("<th class=\"num\">pending</th><th class=\"num\">dead</th>")
-          .append("<th class=\"num\">sent</th><th class=\"num\">dead-lettered</th></tr></thead><tbody>");
+          .append("<th class=\"num\">sent</th><th class=\"num\" title=\"dead-lettered\">DLQ</th></tr></thead><tbody>");
         int maxPending = 0;
         for (Map.Entry<String, PersistentSpool> entry : aQueues.entrySet()) {
             PersistentSpool spool = entry.getValue();
@@ -87,7 +87,7 @@ public final class DashboardView {
               .append("<td class=\"num\">").append(spool.sentCount()).append("</td>")
               .append("<td class=\"num\">").append(spool.deadLetterCount()).append("</td></tr>");
         }
-        sb.append("</tbody></table>");
+        sb.append("</tbody></table></div>");
 
         // depth bars (pending), scaled to the busiest queue
         sb.append("<div class=\"bars\">");

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -29,8 +29,10 @@
         .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
         .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
         .card h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 0 0 12px; }
+        .tablewrap { overflow-x: auto; }
         table { width: 100%; border-collapse: collapse; }
-        th, td { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--border); }
+        .card table { font-size: 12px; }
+        th, td { text-align: left; padding: 4px 6px; border-bottom: 1px solid var(--border); white-space: nowrap; }
         th { color: var(--muted); font-weight: 600; }
         td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         ul { margin: 0; padding-left: 18px; }


### PR DESCRIPTION
## Проблема
Таблица карточки **Delivery queues** (5 колонок) вылезала за узкую карточку сетки (~300px при 2 колонках) и обрезала последнюю колонку `dead-lettered` краем карточки (см. скриншот).

## Фикс (только вёрстка)
- `index.html`: таблица обёрнута логикой прокрутки `.tablewrap { overflow-x: auto }`; ячейки компактнее — `white-space: nowrap`, `padding: 4px 6px`, `font-size: 12px` для таблиц в карточке.
- `DashboardView.queues()`: таблица в `<div class="tablewrap">`, самый широкий заголовок `dead-lettered` → `DLQ` (полное имя в `title`-подсказке). Остальные колонки и столбики глубины без изменений.

Никаких изменений в Java-логике/метриках. `DashboardViewTest` (15) зелёный.

## Проверка
`mvn -B -ntp verify` под JDK 21 → `BUILD SUCCESS`. Таблица помещается в карточку на ~300px и ~560px без обрезки (safety-net горизонтальной прокрутки на совсем узких ширинах).

🤖 Generated with [Claude Code](https://claude.com/claude-code)