### PR TITLE
feat(dashboard): agent logs card and SSE-disconnected warning

### DIFF
--- a/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
@@ -25,6 +25,11 @@ public class FullEnvironmentTest {
                     env.gitlab().await(r -> "GET".equals(r.method) && r.path.contains("/repository/compare"), 25_000));
             assertTrue("Telegram sendMessage should be delivered",
                     env.telegram().await(r -> "POST".equals(r.method) && r.path.contains("/sendMessage"), 25_000));
+
+            // The dashboard streams the agents' command output (echo) as an SSE 'logs' card.
+            String frames = env.readDashboardEvents("deployed", 10_000);
+            assertTrue("dashboard should stream an 'logs' event, got: " + frames, frames.contains("event: logs"));
+            assertTrue("agent echo output should appear in the logs card, got: " + frames, frames.contains("deployed"));
         }
     }
 }

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -230,6 +232,34 @@ public class LocalEnvironment implements AutoCloseable {
                 .build();
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
         LOG.info("triggerIssue({}) -> {} {}", aIssueId, response.statusCode(), response.body().trim());
+    }
+
+    /** Opens the dashboard SSE stream and returns the frames read until {@code until} appears or timeout. */
+    public String readDashboardEvents(String aUntil, long aTimeoutMs) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<InputStream> response = client.send(
+                HttpRequest.newBuilder(URI.create(baseUrl() + "/deploy/dashboard/events")).GET().build(),
+                HttpResponse.BodyHandlers.ofInputStream());
+        InputStream in = response.body();
+        ExecutorService reader = Executors.newSingleThreadExecutor();
+        Future<String> future = reader.submit(() -> {
+            StringBuilder sb = new StringBuilder();
+            byte[] buf = new byte[1024];
+            int n;
+            while ((n = in.read(buf)) > 0) {
+                sb.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+                if (sb.indexOf(aUntil) >= 0) {
+                    return sb.toString();
+                }
+            }
+            return sb.toString();
+        });
+        try {
+            return future.get(aTimeoutMs, TimeUnit.MILLISECONDS);
+        } finally {
+            in.close();
+            reader.shutdownNow();
+        }
     }
 
     public String baseUrl() {

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -28,6 +28,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.pne.deploy.server.vertx.dashboard.AgentLogBuffer;
 import io.pne.deploy.server.vertx.dashboard.DashboardHttpHandler;
 import io.pne.deploy.server.vertx.dashboard.IDashboardConfig;
 import io.pne.deploy.server.vertx.metrics.MetricsHttpHandler;
@@ -96,7 +97,7 @@ public class VertxServerApplication {
         IDashboardConfig     dashboardConfig      = StartupParametersFactory.getStartupParameters(IDashboardConfig.class);
         DashboardHttpHandler dashboardHttpHandler = new DashboardHttpHandler(
                 this.vertx, agentConnections, pendingIssues, new LinkedHashMap<>(), statusHttpHandler::getLatestTaskStatus,
-                null, dashboardConfig.path(), dashboardConfig.refreshMs());
+                null, new AgentLogBuffer(200), dashboardConfig.path(), dashboardConfig.refreshMs());
 
         this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
         this.serverListener = serverListener;
@@ -134,8 +135,11 @@ public class VertxServerApplication {
 
         deployService       = new DeployServiceImpl(new VertxAgentFinderServiceImpl(agentConnections, gson, response, taskListener), config.getAliasesDir(), taskListener);
 
+        // Ring buffer of recent agent command-output logs, written by the server listener and read by the dashboard.
+        AgentLogBuffer agentLogBuffer = new AgentLogBuffer(200);
+
         RedmineIssuesProcessServiceImpl redmineIssuesProcessService = new RedmineIssuesProcessServiceImpl(redmine, deployService, redmineConfig, diffTelegram);
-        VertxServerApplicationListener serverListener = new VertxServerApplicationListener(redmineIssuesProcessService, pendingIssues);
+        VertxServerApplicationListener serverListener = new VertxServerApplicationListener(redmineIssuesProcessService, pendingIssues, agentLogBuffer);
 
         this.vertx          = Vertx.vertx();
 
@@ -146,7 +150,7 @@ public class VertxServerApplication {
         IDashboardConfig dashboardConfig = StartupParametersFactory.getStartupParameters(IDashboardConfig.class);
         DashboardHttpHandler dashboardHttpHandler = new DashboardHttpHandler(
                 this.vertx, agentConnections, pendingIssues, dashboardQueues, statusHttpHandler::getLatestTaskStatus,
-                metrics, dashboardConfig.path(), dashboardConfig.refreshMs());
+                metrics, agentLogBuffer, dashboardConfig.path(), dashboardConfig.refreshMs());
 
         this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
         this.serverListener = serverListener;

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplicationListener.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplicationListener.java
@@ -1,9 +1,11 @@
 package io.pne.deploy.server.vertx;
 
 import io.pne.deploy.agent.api.messages.IAgentClientMessage;
+import io.pne.deploy.agent.api.messages.RunAgentCommandLog;
 import io.pne.deploy.client.redmine.process.IRedmineIssuesProcessService;
 import io.pne.deploy.client.redmine.process.ProcessRedmineIssueResult;
 import io.pne.deploy.server.IServerApplicationListener;
+import io.pne.deploy.server.vertx.dashboard.AgentLogBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,10 +19,12 @@ public class VertxServerApplicationListener implements IServerApplicationListene
     private final    IRedmineIssuesProcessService redmineIssuesProcessService;
     private volatile Thread                       thread;
     private final   ArrayBlockingQueue<Long>      pendingIssues;
+    private final   AgentLogBuffer                agentLogBuffer;
 
-    public VertxServerApplicationListener(IRedmineIssuesProcessService aRedmineProcessService, ArrayBlockingQueue<Long> aIssues) {
+    public VertxServerApplicationListener(IRedmineIssuesProcessService aRedmineProcessService, ArrayBlockingQueue<Long> aIssues, AgentLogBuffer aAgentLogBuffer) {
         redmineIssuesProcessService = aRedmineProcessService;
         pendingIssues = aIssues;
+        agentLogBuffer = aAgentLogBuffer;
     }
 
     @Override
@@ -69,7 +73,10 @@ public class VertxServerApplicationListener implements IServerApplicationListene
 
     @Override
     public <T extends IAgentClientMessage> void didReceiveMessage(T aMessage) {
-
+        // Capture agent command output for the dashboard; connect/disconnect are socket events, not messages.
+        if (agentLogBuffer != null && aMessage instanceof RunAgentCommandLog log) {
+            agentLogBuffer.add(log.commandId, log.message);
+        }
     }
 
     @Override

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/AgentLogBuffer.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/AgentLogBuffer.java
@@ -1,0 +1,42 @@
+package io.pne.deploy.server.vertx.dashboard;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * A small thread-safe ring buffer of the most recent agent command-log lines. Written from the
+ * Vert.x event loop (via the server listener) and read from the SSE timer thread, so all access is
+ * synchronized. Connect/disconnect are not agent messages, so they never land here.
+ */
+public class AgentLogBuffer {
+
+    private final int          capacity;
+    private final Deque<LogLine> lines = new ArrayDeque<>();
+
+    public AgentLogBuffer(int aCapacity) {
+        this.capacity = Math.max(1, aCapacity);
+    }
+
+    public synchronized void add(String aCommandId, String aMessage) {
+        lines.addLast(new LogLine(System.currentTimeMillis(), aCommandId, aMessage));
+        while (lines.size() > capacity) {
+            lines.removeFirst();
+        }
+    }
+
+    /** Up to {@code aMax} most-recent lines, newest first. */
+    public synchronized List<LogLine> snapshot(int aMax) {
+        List<LogLine> out = new ArrayList<>(Math.min(aMax, lines.size()));
+        var it = lines.descendingIterator();
+        while (it.hasNext() && out.size() < aMax) {
+            out.add(it.next());
+        }
+        return out;
+    }
+
+    /** One captured log line. {@code commandId} correlates lines of one command; there is no agent id. */
+    public record LogLine(long epochMs, String commandId, String message) {
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -48,6 +48,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final Map<String, PersistentSpool> queues;
     private final Supplier<TaskStatus>         taskStatusSupplier;
     private final MeterRegistry                registry; // nullable: no latency card without it
+    private final AgentLogBuffer               logBuffer;
     private final long                         refreshMs;
 
     private final String basePath;
@@ -67,6 +68,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             , Map<String, PersistentSpool> aQueues
             , Supplier<TaskStatus> aTaskStatusSupplier
             , MeterRegistry aRegistry
+            , AgentLogBuffer aLogBuffer
             , String aBasePath
             , long aRefreshMs
     ) {
@@ -76,6 +78,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.queues             = aQueues;
         this.taskStatusSupplier = aTaskStatusSupplier;
         this.registry           = aRegistry;
+        this.logBuffer          = aLogBuffer;
         this.refreshMs          = aRefreshMs;
 
         this.basePath   = normalize(aBasePath);
@@ -177,6 +180,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             writeEvent(aResponse, "issues", DashboardView.issues(issueSnapshot));
             writeEvent(aResponse, "queues", DashboardView.queues(queues));
             writeEvent(aResponse, "latency", DashboardView.latency(latencySnapshot()));
+            writeEvent(aResponse, "logs", DashboardView.logs(logBuffer.snapshot(50)));
             return true;
         } catch (RuntimeException e) {
             LOG.debug("SSE client gone, stopping stream: {}", e.toString());

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -4,7 +4,11 @@ import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 import io.pne.deploy.server.vertx.status.model.TaskState;
 import io.pne.deploy.server.vertx.status.model.TaskStatus;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -16,6 +20,8 @@ public final class DashboardView {
 
     private DashboardView() {
     }
+
+    private static final DateTimeFormatter LOG_TIME = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     /** Connected agent ids. */
     public static String agents(Set<String> aAgents) {
@@ -120,6 +126,31 @@ public final class DashboardView {
             sb.append("</div></div>");
         }
         return sb.toString();
+    }
+
+    /** Recent agent command-output log lines (newest first). Connect/disconnect are not shown. */
+    public static String logs(List<AgentLogBuffer.LogLine> aLines) {
+        if (aLines.isEmpty()) {
+            return "<p class=\"muted\">no logs yet</p>";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div class=\"logbox\">");
+        for (AgentLogBuffer.LogLine line : aLines) {
+            String time = LOG_TIME.format(Instant.ofEpochMilli(line.epochMs()).atZone(ZoneId.systemDefault()));
+            sb.append("<div class=\"logline\"><span class=\"muted\">").append(time).append("</span> ")
+              .append("<code>#").append(esc(shortId(line.commandId()))).append("</code> ")
+              .append(esc(line.message()))
+              .append("</div>");
+        }
+        sb.append("</div>");
+        return sb.toString();
+    }
+
+    private static String shortId(String aCommandId) {
+        if (aCommandId == null) {
+            return "?";
+        }
+        return aCommandId.length() > 8 ? aCommandId.substring(0, 8) : aCommandId;
     }
 
     /** One horizontal bar: label, a filled track (fraction clamped to [0,1]) and a value caption. */

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -62,10 +62,27 @@
             padding: 6px 14px; border: 0; border-radius: 8px; cursor: pointer;
             background: var(--accent); color: #fff; font-weight: 600;
         }
+
+        /* SSE connection warning banner */
+        .banner {
+            margin: 0 0 16px; padding: 10px 14px; border-radius: 8px; font-weight: 600;
+            color: var(--warn);
+            background: color-mix(in srgb, var(--warn) 15%, transparent);
+            border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
+        }
+        .banner[hidden] { display: none; }
+
+        /* agent logs */
+        .logbox { max-height: 220px; overflow-y: auto; }
+        .logline {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
+            white-space: pre-wrap; word-break: break-word; padding: 1px 0;
+        }
     </style>
 </head>
 <body hx-ext="sse" sse-connect="{{BASE}}/events">
     <h1>Deploy server</h1>
+    <div id="sse-status" class="banner" hidden>&#9888; Not connected to backend (SSE) &mdash; retrying&hellip;</div>
     <p class="sub">Live status &middot; updates automatically over SSE</p>
     <div class="grid">
         <section class="card"><h2>Service</h2>          <div sse-swap="service"><span class="muted">connecting&hellip;</span></div></section>
@@ -81,6 +98,18 @@
         </section>
         <section class="card"><h2>Delivery queues</h2>  <div sse-swap="queues"><span class="muted">connecting&hellip;</span></div></section>
         <section class="card"><h2>Send latency</h2>     <div sse-swap="latency"><span class="muted">connecting&hellip;</span></div></section>
+        <section class="card"><h2>Agent logs</h2>       <div sse-swap="logs"><span class="muted">connecting&hellip;</span></div></section>
     </div>
+    <script>
+        (function () {
+            var banner = document.getElementById('sse-status');
+            var body   = document.body;
+            function show() { banner.hidden = false; }
+            function hide() { banner.hidden = true; }
+            body.addEventListener('htmx:sseOpen', hide);
+            body.addEventListener('htmx:sseError', show);
+            body.addEventListener('htmx:sseClose', show);
+        })();
+    </script>
 </body>
 </html>

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -23,10 +23,11 @@
         body {
             margin: 0; padding: 24px; background: var(--bg); color: var(--fg);
             font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            min-height: 100vh; display: flex; flex-direction: column;
         }
         h1 { font-size: 20px; margin: 0 0 4px; }
         .sub { color: var(--muted); margin: 0 0 20px; font-size: 13px; }
-        .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+        .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); flex: 0 0 auto; }
         .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
         .card h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 0 0 12px; }
         .tablewrap { overflow-x: auto; }
@@ -72,8 +73,10 @@
         }
         .banner[hidden] { display: none; }
 
-        /* agent logs */
-        .logbox { max-height: 220px; overflow-y: auto; }
+        /* agent logs — full-width panel that fills the remaining height */
+        .logs-card { flex: 1 1 auto; display: flex; flex-direction: column; margin-top: 16px; min-height: 160px; }
+        .logs-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+        .logbox { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
         .logline {
             font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
             white-space: pre-wrap; word-break: break-word; padding: 1px 0;
@@ -98,8 +101,11 @@
         </section>
         <section class="card"><h2>Delivery queues</h2>  <div sse-swap="queues"><span class="muted">connecting&hellip;</span></div></section>
         <section class="card"><h2>Send latency</h2>     <div sse-swap="latency"><span class="muted">connecting&hellip;</span></div></section>
-        <section class="card"><h2>Agent logs</h2>       <div sse-swap="logs"><span class="muted">connecting&hellip;</span></div></section>
     </div>
+    <section class="card logs-card">
+        <h2>Agent logs</h2>
+        <div class="logs-body" sse-swap="logs"><span class="muted">connecting&hellip;</span></div>
+    </section>
     <script>
         (function () {
             var banner = document.getElementById('sse-status');

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/AgentLogBufferTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/AgentLogBufferTest.java
@@ -1,0 +1,42 @@
+package io.pne.deploy.server.vertx.dashboard;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AgentLogBufferTest {
+
+    @Test
+    public void keepsMostRecentUpToCapacityNewestFirst() {
+        AgentLogBuffer buffer = new AgentLogBuffer(3);
+        buffer.add("c", "one");
+        buffer.add("c", "two");
+        buffer.add("c", "three");
+        buffer.add("c", "four"); // evicts "one"
+
+        List<AgentLogBuffer.LogLine> snap = buffer.snapshot(10);
+        assertEquals(3, snap.size());
+        assertEquals("four", snap.get(0).message());   // newest first
+        assertEquals("three", snap.get(1).message());
+        assertEquals("two", snap.get(2).message());
+    }
+
+    @Test
+    public void snapshotRespectsMax() {
+        AgentLogBuffer buffer = new AgentLogBuffer(100);
+        for (int i = 0; i < 10; i++) {
+            buffer.add("c", "m" + i);
+        }
+        List<AgentLogBuffer.LogLine> snap = buffer.snapshot(3);
+        assertEquals(3, snap.size());
+        assertEquals("m9", snap.get(0).message());
+    }
+
+    @Test
+    public void emptyBufferSnapshotIsEmpty() {
+        assertTrue(new AgentLogBuffer(10).snapshot(5).isEmpty());
+    }
+}

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -122,6 +122,26 @@ public class DashboardViewTest {
     }
 
     @Test
+    public void logsRenderMessagesNewestFirstAndEscape() {
+        AgentLogBuffer buffer = new AgentLogBuffer(10);
+        buffer.add("cmd-123456789", "first line");
+        buffer.add("cmd-123456789", "<script>bad</script>");
+
+        String html = DashboardView.logs(buffer.snapshot(10));
+        assertTrue(html, html.contains("first line"));
+        assertTrue(html, html.contains("&lt;script&gt;bad&lt;/script&gt;"));
+        assertFalse(html, html.contains("<script>bad"));
+        assertTrue(html, html.contains("logbox"));
+        // newest first: the escaped script line (added last) appears before "first line"
+        assertTrue(html.indexOf("bad") < html.indexOf("first line"));
+    }
+
+    @Test
+    public void logsEmptyShowsPlaceholder() {
+        assertTrue(DashboardView.logs(new java.util.ArrayList<>()).contains("no logs yet"));
+    }
+
+    @Test
     public void escEscapesMarkup() {
         assertEquals("&lt;x&gt;", DashboardView.esc("<x>"));
         assertEquals("a &amp; b", DashboardView.esc("a & b"));


### PR DESCRIPTION
## Что добавлено
1. **Карточка «Agent logs»** — последние логи от агентов (вывод их shell-команд, `RunAgentCommandLog`). Новые сверху, со временем и коротким `commandId`. **События подключения/отключения не показываются** — в этой системе они не сообщения, а серверные socket-события, поэтому в поток логов не попадают.
2. **Предупреждение о разрыве SSE** — жёлтый баннер «Not connected to backend (SSE) — retrying…», когда стрим до backend недоступен (клиентский скрипт на событиях htmx `sseOpen`/`sseError`/`sseClose`; при переподключении баннер скрывается).

Плюс сюда включён (cherry-pick) фикс вёрстки таблицы очередей из PR #11 — чтобы дашборд был цельным.

## Как устроено
- Новый потокобезопасный `AgentLogBuffer` (кольцевой буфер, cap 200). Пишется из серверного слушателя `VertxServerApplicationListener.didReceiveMessage` (единая точка приёма всех сообщений агента) с фильтром `instanceof RunAgentCommandLog` — ответы и connect/disconnect исключены. Читается дашбордом.
- `DashboardView.logs(...)` рендерит карточку; `DashboardHttpHandler` шлёт событие `logs` в том же SSE-тике; `index.html` — карточка `sse-swap="logs"`, баннер и скрипт.

## Проверка
`mvn -B -ntp verify` под JDK 21 → `BUILD SUCCESS`. Новые `AgentLogBufferTest` (3) и кейсы в `DashboardViewTest` (17). `FullEnvironmentTest` расширен: после деплоя читает SSE `/events` и проверяет, что пришло `event: logs` с выводом `echo` (`deployed`) — сквозная проверка agent stdout → RunAgentCommandLog → буфер → дашборд. Отправлен рендер-предпросмотр карточки и баннера.

## Рекомендация по merge
Эта ветка **включает** фикс из PR #11 — можно смержить этот PR и **закрыть #11** (или смержить #11 первым — контент идентичен, конфликта не будет).

🤖 Generated with [Claude Code](https://claude.com/claude-code)