### PR TITLE
feat(dashboard): config and aliases screens with top nav

### DIFF
--- a/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
@@ -3,6 +3,7 @@ package io.pne.deploy.tests;
 import io.pne.deploy.tests.env.LocalEnvironment;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -30,6 +31,15 @@ public class FullEnvironmentTest {
             String frames = env.readDashboardEvents("deployed", 10_000);
             assertTrue("dashboard should stream an 'logs' event, got: " + frames, frames.contains("event: logs"));
             assertTrue("agent echo output should appear in the logs card, got: " + frames, frames.contains("deployed"));
+
+            // Config screen lists env vars but masks secrets.
+            String config = env.httpGet("/deploy/dashboard/config");
+            assertTrue("config screen should list REDMINE_URL, got: " + config, config.contains("REDMINE_URL"));
+            assertFalse("the telegram token must be masked, not shown: " + config, config.contains("test-token"));
+
+            // Aliases screen lists the demo alias and renders its definition.
+            assertTrue(env.httpGet("/deploy/dashboard/aliases").contains("deploy-demo"));
+            assertTrue(env.httpGet("/deploy/dashboard/aliases/deploy-demo").contains("echo"));
         }
     }
 }

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
@@ -262,6 +262,15 @@ public class LocalEnvironment implements AutoCloseable {
         }
     }
 
+    /** Simple blocking GET of a dashboard path; returns the response body. */
+    public String httpGet(String aPath) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpResponse<String> response = client.send(
+                HttpRequest.newBuilder(URI.create(baseUrl() + aPath)).timeout(Duration.ofSeconds(5)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+
     public String baseUrl() {
         return "http://127.0.0.1:" + serverPort;
     }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -31,6 +31,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.pne.deploy.server.vertx.dashboard.AgentLogBuffer;
 import io.pne.deploy.server.vertx.dashboard.DashboardHttpHandler;
 import io.pne.deploy.server.vertx.dashboard.IDashboardConfig;
+import io.pne.deploy.server.vertx.dashboard.StartupConfigReport;
 import io.pne.deploy.server.vertx.metrics.MetricsHttpHandler;
 import io.pne.deploy.server.vertx.metrics.QueueMetrics;
 import io.vertx.core.Vertx;
@@ -40,6 +41,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.File;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executors;
@@ -97,7 +99,9 @@ public class VertxServerApplication {
         IDashboardConfig     dashboardConfig      = StartupParametersFactory.getStartupParameters(IDashboardConfig.class);
         DashboardHttpHandler dashboardHttpHandler = new DashboardHttpHandler(
                 this.vertx, agentConnections, pendingIssues, new LinkedHashMap<>(), statusHttpHandler::getLatestTaskStatus,
-                null, new AgentLogBuffer(200), dashboardConfig.path(), dashboardConfig.refreshMs());
+                null, new AgentLogBuffer(200),
+                buildConfigReport(redmineConfig, aConfig, dashboardConfig), aConfig.getAliasesDir(),
+                dashboardConfig.path(), dashboardConfig.refreshMs());
 
         this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
         this.serverListener = serverListener;
@@ -150,10 +154,20 @@ public class VertxServerApplication {
         IDashboardConfig dashboardConfig = StartupParametersFactory.getStartupParameters(IDashboardConfig.class);
         DashboardHttpHandler dashboardHttpHandler = new DashboardHttpHandler(
                 this.vertx, agentConnections, pendingIssues, dashboardQueues, statusHttpHandler::getLatestTaskStatus,
-                metrics, agentLogBuffer, dashboardConfig.path(), dashboardConfig.refreshMs());
+                metrics, agentLogBuffer,
+                buildConfigReport(redmineConfig, config, dashboardConfig), config.getAliasesDir(),
+                dashboardConfig.path(), dashboardConfig.refreshMs());
 
         this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
         this.serverListener = serverListener;
+    }
+
+    private static List<StartupConfigReport.Entry> buildConfigReport(
+            IRedmineRemoteConfig aRedmine, IVertxServerConfiguration aVertx, IDashboardConfig aDashboard) {
+        return StartupConfigReport.of(List.of(
+                new StartupConfigReport.Group("Redmine / GitLab / Telegram", IRedmineRemoteConfig.class, aRedmine),
+                new StartupConfigReport.Group("Server", IVertxServerConfiguration.class, aVertx),
+                new StartupConfigReport.Group("Dashboard", IDashboardConfig.class, aDashboard)));
     }
 
     private ITaskExecutionListener createTaskListener(Consumer<TaskStatus> aConsumer, IRedmineRemoteConfig aConfig, TelegramClient aTelegramClient) {

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+import io.pne.deploy.server.service.impl.alias.AliasDescription;
 import io.pne.deploy.server.vertx.AgentConnections;
 import io.pne.deploy.server.vertx.status.model.TaskStatus;
 import io.vertx.core.Handler;
@@ -15,18 +16,23 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -41,6 +47,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardHttpHandler.class);
 
     private static final String LATENCY_METER = "deploy_queue_send_latency";
+    private static final Pattern ALIAS_NAME   = Pattern.compile("^[A-Za-z0-9._-]+$");
 
     private final Vertx                        vertx;
     private final AgentConnections             agents;
@@ -49,6 +56,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final Supplier<TaskStatus>         taskStatusSupplier;
     private final MeterRegistry                registry; // nullable: no latency card without it
     private final AgentLogBuffer               logBuffer;
+    private final List<StartupConfigReport.Entry> configEntries;
+    private final File                         aliasesDir;
     private final long                         refreshMs;
 
     private final String basePath;
@@ -56,6 +65,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final String htmxPath;
     private final String sseJsPath;
     private final String issuePath;
+    private final String configPath;
+    private final String aliasesPath;
 
     private final Buffer indexHtml;
     private final Buffer htmxJs = readResource("/dashboard/htmx.min.js");
@@ -69,6 +80,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             , Supplier<TaskStatus> aTaskStatusSupplier
             , MeterRegistry aRegistry
             , AgentLogBuffer aLogBuffer
+            , List<StartupConfigReport.Entry> aConfigEntries
+            , File aAliasesDir
             , String aBasePath
             , long aRefreshMs
     ) {
@@ -79,13 +92,17 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.taskStatusSupplier = aTaskStatusSupplier;
         this.registry           = aRegistry;
         this.logBuffer          = aLogBuffer;
+        this.configEntries      = aConfigEntries;
+        this.aliasesDir         = aAliasesDir;
         this.refreshMs          = aRefreshMs;
 
-        this.basePath   = normalize(aBasePath);
-        this.eventsPath = basePath + "/events";
-        this.htmxPath   = basePath + "/htmx.min.js";
-        this.sseJsPath  = basePath + "/sse.js";
-        this.issuePath  = basePath + "/issue";
+        this.basePath    = normalize(aBasePath);
+        this.eventsPath  = basePath + "/events";
+        this.htmxPath    = basePath + "/htmx.min.js";
+        this.sseJsPath   = basePath + "/sse.js";
+        this.issuePath   = basePath + "/issue";
+        this.configPath  = basePath + "/config";
+        this.aliasesPath = basePath + "/aliases";
 
         this.indexHtml = Buffer.buffer(readResourceString("/dashboard/index.html").replace("{{BASE}}", basePath));
     }
@@ -106,10 +123,53 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             serve(aRequest, "application/javascript; charset=utf-8", htmxJs);
         } else if (sseJsPath.equals(path)) {
             serve(aRequest, "application/javascript; charset=utf-8", sseJs);
+        } else if (configPath.equals(path)) {
+            serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(DashboardView.config(configEntries)));
+        } else if (aliasesPath.equals(path)) {
+            handleAliasList(aRequest);
+        } else if (path.startsWith(aliasesPath + "/")) {
+            handleAliasDetail(aRequest, path.substring(aliasesPath.length() + 1));
         } else if (basePath.equals(path) || (basePath + "/").equals(path)) {
             serve(aRequest, "text/html; charset=utf-8", indexHtml);
         } else {
             aRequest.response().setStatusCode(404).end("Not found\n");
+        }
+    }
+
+    private void handleAliasList(HttpServerRequest aRequest) {
+        List<String> names = new ArrayList<>();
+        String[] files = aliasesDir == null ? null : aliasesDir.list((dir, name) -> name.endsWith(".yml"));
+        if (files != null) {
+            for (String file : files) {
+                names.add(file.substring(0, file.length() - ".yml".length()));
+            }
+            names.sort(String::compareTo);
+        }
+        serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(DashboardView.aliasList(names, basePath)));
+    }
+
+    private void handleAliasDetail(HttpServerRequest aRequest, String aName) {
+        if (aliasesDir == null || !ALIAS_NAME.matcher(aName).matches()) {
+            aRequest.response().setStatusCode(400).end("bad alias name\n");
+            return;
+        }
+        try {
+            File file = new File(aliasesDir, aName + ".yml");
+            // defence-in-depth against traversal, even though ALIAS_NAME already forbids separators
+            if (!file.getCanonicalPath().startsWith(aliasesDir.getCanonicalPath() + File.separator)) {
+                aRequest.response().setStatusCode(400).end("bad alias name\n");
+                return;
+            }
+            if (!file.isFile()) {
+                serve(aRequest, "text/html; charset=utf-8", Buffer.buffer("<p class=\"muted\">alias not found</p>"));
+                return;
+            }
+            String raw = Files.readString(file.toPath());
+            AliasDescription description = new Yaml().loadAs(raw, AliasDescription.class);
+            serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(DashboardView.aliasDetail(aName, description, raw)));
+        } catch (IOException | RuntimeException e) {
+            LOG.warn("cannot read alias {}", aName, e);
+            serve(aRequest, "text/html; charset=utf-8", Buffer.buffer("<p class=\"pill bad\">cannot read alias</p>"));
         }
     }
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -1,6 +1,8 @@
 package io.pne.deploy.server.vertx.dashboard;
 
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+import io.pne.deploy.server.service.impl.alias.AliasCommand;
+import io.pne.deploy.server.service.impl.alias.AliasDescription;
 import io.pne.deploy.server.vertx.status.model.TaskState;
 import io.pne.deploy.server.vertx.status.model.TaskStatus;
 
@@ -151,6 +153,84 @@ public final class DashboardView {
             return "?";
         }
         return aCommandId.length() > 8 ? aCommandId.substring(0, 8) : aCommandId;
+    }
+
+    /** Grouped table of startup config parameters (secrets already masked in the entries). */
+    public static String config(List<StartupConfigReport.Entry> aEntries) {
+        if (aEntries.isEmpty()) {
+            return "<p class=\"muted\">no config</p>";
+        }
+        StringBuilder sb = new StringBuilder();
+        String currentGroup = null;
+        for (StartupConfigReport.Entry entry : aEntries) {
+            if (!entry.group().equals(currentGroup)) {
+                if (currentGroup != null) {
+                    sb.append("</tbody></table></div>");
+                }
+                currentGroup = entry.group();
+                sb.append("<h3 class=\"cfg-group\">").append(esc(currentGroup)).append("</h3>");
+                sb.append("<div class=\"tablewrap\"><table><thead><tr>")
+                  .append("<th>variable</th><th>value</th><th>default</th></tr></thead><tbody>");
+            }
+            sb.append("<tr><td><code>").append(esc(entry.name())).append("</code></td>")
+              .append("<td>").append(esc(entry.value()));
+            if (!entry.isDefault()) {
+                sb.append(" <span class=\"pill warn\">overridden</span>");
+            }
+            sb.append("</td><td class=\"muted\"><code>").append(esc(entry.def())).append("</code></td></tr>");
+        }
+        sb.append("</tbody></table></div>");
+        return sb.toString();
+    }
+
+    /** Clickable list of alias names; each loads its detail into {@code #alias-detail} via htmx. */
+    public static String aliasList(List<String> aNames, String aBasePath) {
+        if (aNames.isEmpty()) {
+            return "<p class=\"muted\">no aliases</p>";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div class=\"alias-list\">");
+        for (String name : aNames) {
+            sb.append("<button class=\"alias-item\" hx-get=\"").append(esc(aBasePath)).append("/aliases/").append(esc(name))
+              .append("\" hx-target=\"#alias-detail\" hx-swap=\"innerHTML\"><code>").append(esc(name)).append("</code></button>");
+        }
+        sb.append("</div>");
+        return sb.toString();
+    }
+
+    /** Rendered alias definition: each command's agents/command/arguments, plus the raw YAML. */
+    public static String aliasDetail(String aName, AliasDescription aDescription, String aRawYaml) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<h3 class=\"cfg-group\">").append(esc(aName)).append("</h3>");
+        if (aDescription == null || aDescription.commands == null || aDescription.commands.isEmpty()) {
+            sb.append("<p class=\"muted\">no commands / could not parse</p>");
+        } else {
+            int index = 1;
+            for (AliasCommand command : aDescription.commands) {
+                sb.append("<div class=\"alias-cmd\">");
+                sb.append("<div class=\"kv\"><span>#").append(index++).append(" command</span><b><code>")
+                  .append(esc(command.name)).append("</code></b></div>");
+                sb.append("<div class=\"kv\"><span>agents</span><span>");
+                if (command.agents != null) {
+                    for (String agent : command.agents.split(",")) {
+                        sb.append("<span class=\"chip\">").append(esc(agent.trim())).append("</span>");
+                    }
+                }
+                sb.append("</span></div>");
+                if (command.arguments != null && !command.arguments.isEmpty()) {
+                    sb.append("<div class=\"muted\">arguments</div><ul>");
+                    for (String arg : command.arguments) {
+                        sb.append("<li><code>").append(esc(arg)).append("</code></li>");
+                    }
+                    sb.append("</ul>");
+                }
+                sb.append("</div>");
+            }
+        }
+        if (aRawYaml != null) {
+            sb.append("<details class=\"raw\"><summary>raw YAML</summary><pre>").append(esc(aRawYaml)).append("</pre></details>");
+        }
+        return sb.toString();
     }
 
     /** One horizontal bar: label, a filled track (fraction clamped to [0,1]) and a value caption. */

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/StartupConfigReport.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/StartupConfigReport.java
@@ -1,0 +1,66 @@
+package io.pne.deploy.server.vertx.dashboard;
+
+import com.payneteasy.startup.parameters.AStartupParameter;
+import io.pne.deploy.util.env.IStartupConfig;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Builds a masked, display-friendly report of all {@code @AStartupParameter} settings for the config
+ * screen. Reflects over each config interface's methods (the annotations live on the interface, not on
+ * the resolved dynamic proxy) and invokes each to read the effective value. Secrets are never shown.
+ */
+public final class StartupConfigReport {
+
+    /** Extra safety net: mask credential-like names even if the interface forgot {@code maskVariable=true}. */
+    private static final Pattern SECRET_NAME = Pattern.compile("(?i).*(KEY|TOKEN|SECRET|PASSWORD).*");
+
+    private StartupConfigReport() {
+    }
+
+    /** One config interface plus its resolved instance. */
+    public record Group(String label, Class<? extends IStartupConfig> iface, IStartupConfig instance) {
+    }
+
+    /** One rendered parameter row. {@code value} is already masked when {@code masked} is true. */
+    public record Entry(String group, String name, String value, String def, boolean masked, boolean isDefault) {
+    }
+
+    public static List<Entry> of(List<Group> aGroups) {
+        List<Entry> out = new ArrayList<>();
+        for (Group group : aGroups) {
+            List<Entry> groupEntries = new ArrayList<>();
+            for (Method method : group.iface().getMethods()) {
+                AStartupParameter annotation = method.getAnnotation(AStartupParameter.class);
+                if (annotation == null) {
+                    continue;
+                }
+                String def       = annotation.value();
+                String effective = invoke(method, group.instance());
+                boolean masked   = annotation.maskVariable() || SECRET_NAME.matcher(annotation.name()).matches();
+                boolean isDefault = effective.equals(def);
+                String display   = masked ? maskValue(effective) : effective;
+                groupEntries.add(new Entry(group.label(), annotation.name(), display, def, masked, isDefault));
+            }
+            groupEntries.sort(Comparator.comparing(Entry::name));
+            out.addAll(groupEntries);
+        }
+        return out;
+    }
+
+    private static String invoke(Method aMethod, Object aInstance) {
+        try {
+            return String.valueOf(aMethod.invoke(aInstance));
+        } catch (ReflectiveOperationException e) {
+            return "(error)";
+        }
+    }
+
+    private static String maskValue(String aValue) {
+        return aValue == null || aValue.isEmpty() ? "(not set)" : "•••• (set)";
+    }
+}

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -81,31 +81,77 @@
             font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
             white-space: pre-wrap; word-break: break-word; padding: 1px 0;
         }
+
+        /* top menu + screens */
+        .tabs { display: flex; gap: 8px; margin: 0 0 16px; flex: 0 0 auto; }
+        .tab { padding: 6px 14px; border-radius: 8px; cursor: pointer; font: inherit; font-weight: 600;
+               color: var(--muted); background: transparent; border: 1px solid var(--border); }
+        .tab.active { color: var(--fg); background: var(--card); border-color: var(--accent); }
+        .screen { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
+        .screen[hidden] { display: none; }
+        #screen-config, #screen-aliases { overflow-y: auto; }
+
+        /* config screen */
+        .cfg-group { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 16px 0 8px; }
+        .cfg-group:first-child { margin-top: 0; }
+
+        /* aliases screen */
+        .aliases-layout { display: flex; gap: 16px; align-items: flex-start; flex-wrap: wrap; }
+        .aliases-list-pane { flex: 0 0 200px; }
+        #alias-detail { flex: 1 1 320px; }
+        .alias-list { display: flex; flex-direction: column; gap: 6px; }
+        .alias-item { text-align: left; padding: 8px 10px; border-radius: 8px; cursor: pointer; font: inherit;
+                      color: var(--fg); background: var(--card); border: 1px solid var(--border); }
+        .alias-item:hover { border-color: var(--accent); }
+        .alias-cmd { border: 1px solid var(--border); border-radius: 8px; padding: 10px; margin-bottom: 10px; }
+        .chip { display: inline-block; padding: 1px 8px; margin: 0 4px 4px 0; border-radius: 999px; font-size: 12px; background: var(--track); }
+        .raw { margin-top: 8px; }
+        pre { overflow-x: auto; background: var(--track); padding: 10px; border-radius: 8px; font-size: 12px; }
     </style>
 </head>
 <body hx-ext="sse" sse-connect="{{BASE}}/events">
     <h1>Deploy server</h1>
     <div id="sse-status" class="banner" hidden>&#9888; Not connected to backend (SSE) &mdash; retrying&hellip;</div>
-    <p class="sub">Live status &middot; updates automatically over SSE</p>
-    <div class="grid">
-        <section class="card"><h2>Service</h2>          <div sse-swap="service"><span class="muted">connecting&hellip;</span></div></section>
-        <section class="card"><h2>Connected agents</h2> <div sse-swap="agents"><span class="muted">connecting&hellip;</span></div></section>
-        <section class="card"><h2>Current task</h2>     <div sse-swap="status"><span class="muted">connecting&hellip;</span></div></section>
-        <section class="card">
-            <h2>Issues queue</h2>
-            <form class="issue-form" hx-post="{{BASE}}/issue" hx-target="#issues-list" hx-swap="innerHTML">
-                <input type="number" name="issue_id" min="1" placeholder="issue id" required>
-                <button type="submit">Add</button>
-            </form>
-            <div id="issues-list" sse-swap="issues"><span class="muted">connecting&hellip;</span></div>
+    <nav class="tabs">
+        <button class="tab active" data-screen="live">Live</button>
+        <button class="tab" data-screen="config">Config</button>
+        <button class="tab" data-screen="aliases">Aliases</button>
+    </nav>
+
+    <section id="screen-live" class="screen">
+        <p class="sub">Live status &middot; updates automatically over SSE</p>
+        <div class="grid">
+            <section class="card"><h2>Service</h2>          <div sse-swap="service"><span class="muted">connecting&hellip;</span></div></section>
+            <section class="card"><h2>Connected agents</h2> <div sse-swap="agents"><span class="muted">connecting&hellip;</span></div></section>
+            <section class="card"><h2>Current task</h2>     <div sse-swap="status"><span class="muted">connecting&hellip;</span></div></section>
+            <section class="card">
+                <h2>Issues queue</h2>
+                <form class="issue-form" hx-post="{{BASE}}/issue" hx-target="#issues-list" hx-swap="innerHTML">
+                    <input type="number" name="issue_id" min="1" placeholder="issue id" required>
+                    <button type="submit">Add</button>
+                </form>
+                <div id="issues-list" sse-swap="issues"><span class="muted">connecting&hellip;</span></div>
+            </section>
+            <section class="card"><h2>Delivery queues</h2>  <div sse-swap="queues"><span class="muted">connecting&hellip;</span></div></section>
+            <section class="card"><h2>Send latency</h2>     <div sse-swap="latency"><span class="muted">connecting&hellip;</span></div></section>
+        </div>
+        <section class="card logs-card">
+            <h2>Agent logs</h2>
+            <div class="logs-body" sse-swap="logs"><span class="muted">connecting&hellip;</span></div>
         </section>
-        <section class="card"><h2>Delivery queues</h2>  <div sse-swap="queues"><span class="muted">connecting&hellip;</span></div></section>
-        <section class="card"><h2>Send latency</h2>     <div sse-swap="latency"><span class="muted">connecting&hellip;</span></div></section>
-    </div>
-    <section class="card logs-card">
-        <h2>Agent logs</h2>
-        <div class="logs-body" sse-swap="logs"><span class="muted">connecting&hellip;</span></div>
     </section>
+
+    <section id="screen-config" class="screen" hidden>
+        <div hx-get="{{BASE}}/config" hx-trigger="load"><span class="muted">loading&hellip;</span></div>
+    </section>
+
+    <section id="screen-aliases" class="screen" hidden>
+        <div class="aliases-layout">
+            <div class="aliases-list-pane" hx-get="{{BASE}}/aliases" hx-trigger="load"><span class="muted">loading&hellip;</span></div>
+            <div id="alias-detail" class="card"><span class="muted">select an alias&hellip;</span></div>
+        </div>
+    </section>
+
     <script>
         (function () {
             var banner = document.getElementById('sse-status');
@@ -115,6 +161,21 @@
             body.addEventListener('htmx:sseOpen', hide);
             body.addEventListener('htmx:sseError', show);
             body.addEventListener('htmx:sseClose', show);
+        })();
+
+        (function () {
+            var tabs    = document.querySelectorAll('.tab');
+            var screens = { live: 'screen-live', config: 'screen-config', aliases: 'screen-aliases' };
+            tabs.forEach(function (tab) {
+                tab.addEventListener('click', function () {
+                    tabs.forEach(function (t) { t.classList.remove('active'); });
+                    tab.classList.add('active');
+                    var want = tab.getAttribute('data-screen');
+                    Object.keys(screens).forEach(function (key) {
+                        document.getElementById(screens[key]).hidden = (key !== want);
+                    });
+                });
+            });
         })();
     </script>
 </body>

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -1,15 +1,19 @@
 package io.pne.deploy.server.vertx.dashboard;
 
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+import io.pne.deploy.server.service.impl.alias.AliasCommand;
+import io.pne.deploy.server.service.impl.alias.AliasDescription;
 import io.pne.deploy.server.vertx.status.model.TaskState;
 import io.pne.deploy.server.vertx.status.model.TaskStatus;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -139,6 +143,53 @@ public class DashboardViewTest {
     @Test
     public void logsEmptyShowsPlaceholder() {
         assertTrue(DashboardView.logs(new java.util.ArrayList<>()).contains("no logs yet"));
+    }
+
+    @Test
+    public void configRendersNamesGroupsAndMaskedValue() {
+        List<StartupConfigReport.Entry> entries = List.of(
+                new StartupConfigReport.Entry("Redmine", "REDMINE_URL", "http://x", "", false, false),
+                new StartupConfigReport.Entry("Redmine", "TELEGRAM_TOKEN", "•••• (set)", "", true, false));
+        String html = DashboardView.config(entries);
+        assertTrue(html, html.contains("Redmine"));
+        assertTrue(html, html.contains("REDMINE_URL"));
+        assertTrue(html, html.contains("•••• (set)"));
+    }
+
+    @Test
+    public void aliasListRendersButtonsWithHxGet() {
+        String html = DashboardView.aliasList(List.of("deploy-demo"), "/deploy/dashboard");
+        assertTrue(html, html.contains("deploy-demo"));
+        assertTrue(html, html.contains("hx-get=\"/deploy/dashboard/aliases/deploy-demo\""));
+    }
+
+    @Test
+    public void aliasListEmptyShowsPlaceholder() {
+        assertTrue(DashboardView.aliasList(new ArrayList<>(), "/x").contains("no aliases"));
+    }
+
+    @Test
+    public void aliasDetailRendersCommandsAndEscapes() {
+        AliasCommand command = new AliasCommand();
+        command.agents = "agent-1,agent-2";
+        command.name = "echo";
+        command.arguments = List.of("<hi>", "$1");
+        AliasDescription description = new AliasDescription();
+        description.commands = List.of(command);
+
+        String html = DashboardView.aliasDetail("deploy-demo", description, "commands: []");
+        assertTrue(html, html.contains("deploy-demo"));
+        assertTrue(html, html.contains("echo"));
+        assertTrue(html, html.contains("agent-1"));
+        assertTrue(html, html.contains("agent-2"));
+        assertTrue(html, html.contains("&lt;hi&gt;"));
+        assertFalse(html, html.contains("<hi>"));
+        assertTrue(html, html.contains("raw YAML"));
+    }
+
+    @Test
+    public void aliasDetailNullDescriptionIsSafe() {
+        assertTrue(DashboardView.aliasDetail("x", null, null).contains("could not parse"));
     }
 
     @Test

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/StartupConfigReportTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/StartupConfigReportTest.java
@@ -1,0 +1,42 @@
+package io.pne.deploy.server.vertx.dashboard;
+
+import com.payneteasy.startup.parameters.StartupParametersFactory;
+import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
+import io.pne.deploy.server.vertx.IVertxServerConfiguration;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StartupConfigReportTest {
+
+    @Test
+    public void reportsEntriesAndMasksSecrets() {
+        List<StartupConfigReport.Entry> entries = StartupConfigReport.of(List.of(
+                new StartupConfigReport.Group("Redmine", IRedmineRemoteConfig.class,
+                        StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class)),
+                new StartupConfigReport.Group("Server", IVertxServerConfiguration.class,
+                        StartupParametersFactory.getStartupParameters(IVertxServerConfiguration.class)),
+                new StartupConfigReport.Group("Dashboard", IDashboardConfig.class,
+                        StartupParametersFactory.getStartupParameters(IDashboardConfig.class))));
+
+        assertTrue(has(entries, "REDMINE_URL"));
+        assertTrue(has(entries, "VERTX_SERVER_PORT"));
+        assertTrue(has(entries, "DASHBOARD_PATH"));
+
+        assertTrue("REDMINE_API_ACCESS_KEY must be masked", masked(entries, "REDMINE_API_ACCESS_KEY"));
+        assertTrue("TELEGRAM_TOKEN must be masked", masked(entries, "TELEGRAM_TOKEN"));
+        assertTrue("GITLAB_API_KEY must be masked by the name rule", masked(entries, "GITLAB_API_KEY"));
+        assertFalse("REDMINE_URL must not be masked", masked(entries, "REDMINE_URL"));
+    }
+
+    private static boolean has(List<StartupConfigReport.Entry> aEntries, String aName) {
+        return aEntries.stream().anyMatch(e -> e.name().equals(aName));
+    }
+
+    private static boolean masked(List<StartupConfigReport.Entry> aEntries, String aName) {
+        return aEntries.stream().anyMatch(e -> e.name().equals(aName) && e.masked());
+    }
+}


### PR DESCRIPTION
## Что добавлено
Верхнее **меню** переключает три экрана дашборда: **Live** (прежний SSE-экран), **Config**, **Aliases**.

1. **Config** — все env-переменные из `@AStartupParameter`-интерфейсов (`IRedmineRemoteConfig`, `IVertxServerConfiguration`, `IDashboardConfig`), сгруппированы по интерфейсу: имя переменной, текущее значение, дефолт, метка `overridden`. **Секреты маскируются** — по флагу `maskVariable` (`REDMINE_API_ACCESS_KEY`, `TELEGRAM_TOKEN`) и дополнительно по имени (`KEY|TOKEN|SECRET|PASSWORD`), поэтому `GITLAB_API_KEY` тоже скрыт («•••• (set)»).
2. **Aliases** — список `*.yml` из `VERTX_ALIASES_DIR`; по клику — детально: команды (agents-чипы, command, arguments) + сырой YAML. Имя алиаса валидируется (`[A-Za-z0-9._-]+`) + защита от path traversal (canonical-path). Шаблон показывается как есть (без подстановки `$1`/`$ISSUE_ID`).

## Как устроено
- `StartupConfigReport` рефлексией по интерфейсу читает `@AStartupParameter{name,value,maskVariable}` и вызывает метод на резолвнутом прокси → эффективное значение; маскирование по флагу + имени. Собирается один раз в `VertxServerApplication`.
- Новые роуты в `DashboardHttpHandler`: `GET <base>/config`, `/aliases`, `/aliases/<name>`; рендер — чистые методы `DashboardView.config/aliasList/aliasDetail` (с `esc`). Алиасы парсятся `new Yaml().loadAs(...)`.
- `index.html`: `<nav>` + три `.screen`, client-side переключение вкладок; Config/Aliases грузятся по `hx-get` (`hx-trigger=load`), детальный алиас — по клику через htmx. SSE-экран остаётся подключённым.

## Проверка
`mvn -B -ntp verify` под JDK 21 → `BUILD SUCCESS`. Новый `StartupConfigReportTest` (секреты masked), кейсы в `DashboardViewTest` (config/aliasList/aliasDetail + экранирование), `FullEnvironmentTest` расширен: GET `/config` содержит `REDMINE_URL` и **не** содержит `test-token` (маска), `/aliases` содержит `deploy-demo`, `/aliases/deploy-demo` содержит `echo`. Отправлен интерактивный рендер-предпросмотр меню/экранов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)