### PR TITLE
ci: publish fat jars as a GitHub release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags: [ '*' ]        # any tag push cuts a release
+
+permissions:
+  contents: write        # required to create the GitHub release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build fat jars
+        run: mvn -B -ntp package
+
+      - name: Stage release artifacts
+        run: |
+          mkdir -p release
+          cp server-vertx/target/*-jar-with-dependencies.jar    "release/deploy-server-${GITHUB_REF_NAME}.jar"
+          cp agent-websocket/target/*-jar-with-dependencies.jar "release/deploy-agent-${GITHUB_REF_NAME}.jar"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" release/*.jar --title "$GITHUB_REF_NAME" --generate-notes

--- a/README.md
+++ b/README.md
@@ -209,3 +209,21 @@ plus standard JVM (memory/GC/threads) and process metrics.
 
 GitHub Actions (`.github/workflows/ci.yml`) builds and tests on Temurin JDK 21 with
 `mvn -B -ntp verify`, on pushes to `master` and on all pull requests.
+
+## Releases
+
+Pushing a git **tag** triggers `.github/workflows/release.yml`: it builds the fat jars on JDK 21 and
+publishes a GitHub Release for the tag with the two runnable artifacts attached —
+`deploy-server-<tag>.jar` and `deploy-agent-<tag>.jar`.
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+Then download and run, e.g.:
+
+```bash
+java -jar deploy-server-v1.0.0.jar   # env config as in "Running the server"
+java -jar deploy-agent-v1.0.0.jar    # SERVER_BASE_URL + AGENT_ID
+```


### PR DESCRIPTION
## Что
На пуш **тега** собираем fat jar'ы и публикуем **GitHub Release** с ними.

`.github/workflows/release.yml` (триггер `on: push: tags: ['*']`, `permissions: contents: write`):
1. checkout + JDK 21 (Temurin, cache maven);
2. `mvn -B -ntp package` (тесты прогоняются — сломанный тег релиз не создаст);
3. копирует `server-vertx/target/*-jar-with-dependencies.jar` и `agent-websocket/target/*-jar-with-dependencies.jar` в `deploy-server-<tag>.jar` / `deploy-agent-<tag>.jar`;
4. `gh release create "<tag>" release/*.jar --generate-notes` (штатный `gh` + `GITHUB_TOKEN`, без сторонних actions).

Триггер только по тегам — на ветки/PR не влияет; существующий `ci.yml` без изменений.

## Использование
```bash
git tag v1.0.0 && git push origin v1.0.0
```
→ появится релиз с двумя jar. Раздел «Releases» добавлен в README.

## Вне объёма
- Проставление версии тега внутрь jar (нужен `${revision}`/`versions:set`) — пока версию несёт имя ассета.
- `release-deploy-server.sh` (заливка на внутренний endpoint) — не трогаю.

🤖 Generated with [Claude Code](https://claude.com/claude-code)