### PR TITLE
fix(dashboard): non-decaying send-latency percentiles and sorted agents

### DIFF
--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -33,7 +33,7 @@ public final class DashboardView {
             sb.append("<p class=\"muted\">no agents connected</p>");
         } else {
             sb.append("<ul>");
-            for (String agent : aAgents) {
+            for (String agent : new java.util.TreeSet<>(aAgents)) { // alphabetical
                 sb.append("<li><code>").append(esc(agent)).append("</code></li>");
             }
             sb.append("</ul>");

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/QueueMetrics.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/metrics/QueueMetrics.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
 
@@ -46,6 +47,10 @@ public final class QueueMetrics {
                 .description("Latency of a successful send/edit call to the external service")
                 .publishPercentileHistogram()
                 .publishPercentiles(0.5, 0.95, 0.99)
+                // Sends are infrequent; keep max/percentiles all-time instead of decaying to 0 after the
+                // default 2-minute window (mean/count are cumulative anyway).
+                .distributionStatisticExpiry(Duration.ofDays(3650))
+                .distributionStatisticBufferLength(1)
                 .tag("queue", aQueue)
                 .register(aRegistry);
         return nanos -> timer.record(nanos, TimeUnit.NANOSECONDS);

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -37,6 +37,17 @@ public class DashboardViewTest {
     }
 
     @Test
+    public void agentsAreSortedAlphabetically() {
+        String html = DashboardView.agents(new LinkedHashSet<>(List.of("dvpn-2", "ipro-1", "dpub-1")));
+        int dpub = html.indexOf("dpub-1");
+        int dvpn = html.indexOf("dvpn-2");
+        int ipro = html.indexOf("ipro-1");
+        assertTrue(dpub >= 0 && dvpn >= 0 && ipro >= 0);
+        assertTrue("dpub-1 before dvpn-2", dpub < dvpn);
+        assertTrue("dvpn-2 before ipro-1", dvpn < ipro);
+    }
+
+    @Test
     public void agentsEmptyShowsPlaceholder() {
         String html = DashboardView.agents(emptySet());
         assertTrue(html, html.contains("no agents connected"));

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/metrics/QueueMetricsTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/metrics/QueueMetricsTest.java
@@ -1,5 +1,11 @@
 package io.pne.deploy.server.vertx.metrics;
 
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
@@ -7,6 +13,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
 
 import static org.junit.Assert.assertEquals;
@@ -44,5 +52,31 @@ public class QueueMetricsTest {
 
         assertEquals(1L, registry.get("deploy_queue_send_latency").tag("queue", "telegram").timer().count());
         assertTrue(registry.scrape().contains("deploy_queue_send_latency_seconds_bucket"));
+    }
+
+    @Test
+    public void sendLatencyMaxAndPercentilesDoNotDecayToZero() {
+        MockClock clock = new MockClock();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+        LongConsumer recorder = QueueMetrics.sendLatencyRecorder(registry, "telegram");
+
+        recorder.accept(120_000_000L); // 120 ms
+
+        // Advance far beyond the default 2-minute distribution-statistic window; with the fix the
+        // window does not rotate, so max/percentiles keep the recorded value instead of decaying to 0.
+        clock.add(Duration.ofMinutes(5));
+
+        Timer timer = registry.find("deploy_queue_send_latency").tag("queue", "telegram").timer();
+        HistogramSnapshot snap = timer.takeSnapshot();
+
+        assertTrue("max must not decay to 0", snap.max(TimeUnit.MILLISECONDS) > 0.0);
+
+        double p95 = 0.0;
+        for (ValueAtPercentile v : snap.percentileValues()) {
+            if (Math.abs(v.percentile() - 0.95) < 1e-6) {
+                p95 = v.value(TimeUnit.MILLISECONDS);
+            }
+        }
+        assertTrue("p95 must not decay to 0, was " + p95, p95 > 0.0);
     }
 }


### PR DESCRIPTION
## Проблемы
1. **Send latency** показывал `0.0 ms` для p50/p95/p99 **и max**, хотя `mean`/`n` верные.
2. **Connected agents** — список в произвольном порядке.

## Причина #1
У latency-таймера (`QueueMetrics.sendLatencyRecorder`) не задан `distributionStatisticExpiry` → используется дефолтное окно **2 минуты**. В micrometer `count`/`mean` кумулятивны, а `max` и перцентили (`publishPercentiles`) — оконные (`TimeWindowMax`/`TimeWindowPercentileHistogram`). Отправки редкие, поэтому между ними окно ротируется в пустое → max и перцентили = 0, а mean/count остаются. Точно совпадает со скриншотом (telegram n=16, mean 126ms, всё остальное 0).

## Фикс
- `QueueMetrics`: добавлены `.distributionStatisticExpiry(Duration.ofDays(3650))` + `.distributionStatisticBufferLength(1)` — статистики распределения становятся **all-time** (не затухают). Память ограничена (гистограмма с фикс. бакетами + O(1) max).
- `DashboardView.agents`: рендер по алфавиту (`new TreeSet<>(...)`).

## Проверка
`mvn -B -ntp verify` под JDK 21 → `BUILD SUCCESS`. Новый тест `QueueMetricsTest` с `MockClock`: после записи сэмпла и сдвига часов на 5 минут `max` и p95 **> 0** (без фикса затухли бы в 0 — регрессионный guard). Тест `DashboardViewTest` на алфавитный порядок агентов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)