### PR TITLE
feat(dashboard): redesign Aliases tab (sidebar + command cards)

### DIFF
--- a/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
@@ -39,7 +39,7 @@ public class FullEnvironmentTest {
 
             // Aliases screen lists the demo alias and renders its definition.
             assertTrue(env.httpGet("/deploy/dashboard/aliases").contains("deploy-demo"));
-            assertTrue(env.httpGet("/deploy/dashboard/aliases/deploy-demo").contains("echo"));
+            assertTrue(env.httpGet("/deploy/dashboard/alias?name=deploy-demo").contains("echo"));
         }
     }
 }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -67,6 +68,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final String issuePath;
     private final String configPath;
     private final String aliasesPath;
+    private final String aliasPath;
 
     private final Buffer indexHtml;
     private final Buffer htmxJs = readResource("/dashboard/htmx.min.js");
@@ -103,6 +105,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.issuePath   = basePath + "/issue";
         this.configPath  = basePath + "/config";
         this.aliasesPath = basePath + "/aliases";
+        this.aliasPath   = basePath + "/alias";
 
         this.indexHtml = Buffer.buffer(readResourceString("/dashboard/index.html").replace("{{BASE}}", basePath));
     }
@@ -127,8 +130,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(DashboardView.config(configEntries)));
         } else if (aliasesPath.equals(path)) {
             handleAliasList(aRequest);
-        } else if (path.startsWith(aliasesPath + "/")) {
-            handleAliasDetail(aRequest, path.substring(aliasesPath.length() + 1));
+        } else if (aliasPath.equals(path)) {
+            handleAliasDetail(aRequest, aRequest.getParam("name"));
         } else if (basePath.equals(path) || (basePath + "/").equals(path)) {
             serve(aRequest, "text/html; charset=utf-8", indexHtml);
         } else {
@@ -137,19 +140,29 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     }
 
     private void handleAliasList(HttpServerRequest aRequest) {
-        List<String> names = new ArrayList<>();
+        List<DashboardView.AliasInfo> aliases = new ArrayList<>();
         String[] files = aliasesDir == null ? null : aliasesDir.list((dir, name) -> name.endsWith(".yml"));
         if (files != null) {
+            Arrays.sort(files);
             for (String file : files) {
-                names.add(file.substring(0, file.length() - ".yml".length()));
+                String name = file.substring(0, file.length() - ".yml".length());
+                aliases.add(new DashboardView.AliasInfo(name, commandCount(new File(aliasesDir, file))));
             }
-            names.sort(String::compareTo);
         }
-        serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(DashboardView.aliasList(names, basePath)));
+        serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(DashboardView.aliasSidebar(aliases, basePath)));
+    }
+
+    private static int commandCount(File aFile) {
+        try {
+            AliasDescription description = new Yaml().loadAs(Files.readString(aFile.toPath()), AliasDescription.class);
+            return description == null || description.commands == null ? 0 : description.commands.size();
+        } catch (IOException | RuntimeException e) {
+            return 0;
+        }
     }
 
     private void handleAliasDetail(HttpServerRequest aRequest, String aName) {
-        if (aliasesDir == null || !ALIAS_NAME.matcher(aName).matches()) {
+        if (aliasesDir == null || aName == null || !ALIAS_NAME.matcher(aName).matches()) {
             aRequest.response().setStatusCode(400).end("bad alias name\n");
             return;
         }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -183,52 +183,75 @@ public final class DashboardView {
         return sb.toString();
     }
 
-    /** Clickable list of alias names; each loads its detail into {@code #alias-detail} via htmx. */
-    public static String aliasList(List<String> aNames, String aBasePath) {
-        if (aNames.isEmpty()) {
-            return "<p class=\"muted\">no aliases</p>";
-        }
+    /** One alias in the sidebar list: name + number of commands. */
+    public record AliasInfo(String name, int commandCount) {
+    }
+
+    /** Aliases sidebar: header (title + count) + client-side filter input + clickable list. */
+    public static String aliasSidebar(List<AliasInfo> aAliases, String aBasePath) {
         StringBuilder sb = new StringBuilder();
+        sb.append("<aside class=\"alias-side\">");
+        sb.append("<div class=\"alias-side-head\"><div class=\"alias-side-row\">")
+          .append("<span class=\"alias-side-title\">Aliases</span>")
+          .append("<span class=\"alias-count\">").append(aAliases.size()).append("</span></div>")
+          .append("<input class=\"alias-filter\" type=\"text\" placeholder=\"filter&hellip;\" autocomplete=\"off\" spellcheck=\"false\"></div>");
         sb.append("<div class=\"alias-list\">");
-        for (String name : aNames) {
-            sb.append("<button class=\"alias-item\" hx-get=\"").append(esc(aBasePath)).append("/aliases/").append(esc(name))
-              .append("\" hx-target=\"#alias-detail\" hx-swap=\"innerHTML\"><code>").append(esc(name)).append("</code></button>");
+        if (aAliases.isEmpty()) {
+            sb.append("<div class=\"muted\" style=\"padding:8px 10px\">no aliases</div>");
+        } else {
+            for (AliasInfo alias : aAliases) {
+                String meta = alias.commandCount() == 1 ? "1 command" : alias.commandCount() + " commands";
+                sb.append("<button class=\"alias-item\" hx-get=\"").append(esc(aBasePath)).append("/alias?name=").append(esc(alias.name()))
+                  .append("\" hx-target=\"#alias-detail\" hx-swap=\"innerHTML\">")
+                  .append("<span class=\"alias-name\">").append(esc(alias.name())).append("</span>")
+                  .append("<span class=\"alias-sub\">").append(meta).append("</span></button>");
+            }
+            sb.append("<div class=\"alias-nomatch\">no matches</div>");
         }
-        sb.append("</div>");
+        sb.append("</div></aside>");
         return sb.toString();
     }
 
-    /** Rendered alias definition: each command's agents/command/arguments, plus the raw YAML. */
+    /** Rendered alias definition: per-command agents/name/arguments cards + a toggleable raw-YAML block. */
     public static String aliasDetail(String aName, AliasDescription aDescription, String aRawYaml) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<h3 class=\"cfg-group\">").append(esc(aName)).append("</h3>");
+        sb.append("<div class=\"alias-head\"><h2 class=\"alias-title\">").append(esc(aName)).append("</h2>");
+        if (aRawYaml != null) {
+            sb.append("<button class=\"alias-rawbtn\" onclick=\"var r=document.getElementById('alias-raw');")
+              .append("r.hidden=!r.hidden;this.textContent=r.hidden?'show yaml':'hide yaml';\">show yaml</button>");
+        }
+        sb.append("</div>");
+
         if (aDescription == null || aDescription.commands == null || aDescription.commands.isEmpty()) {
             sb.append("<p class=\"muted\">no commands / could not parse</p>");
         } else {
             int index = 1;
             for (AliasCommand command : aDescription.commands) {
-                sb.append("<div class=\"alias-cmd\">");
-                sb.append("<div class=\"kv\"><span>#").append(index++).append(" command</span><b><code>")
-                  .append(esc(command.name)).append("</code></b></div>");
-                sb.append("<div class=\"kv\"><span>agents</span><span>");
+                sb.append("<section class=\"cmd-card\"><div class=\"cmd-head\">")
+                  .append("<span class=\"cmd-num\">").append(index++).append("</span>")
+                  .append("<span class=\"cmd-label\">agents</span><span class=\"chips\">");
                 if (command.agents != null) {
                     for (String agent : command.agents.split(",")) {
                         sb.append("<span class=\"chip\">").append(esc(agent.trim())).append("</span>");
                     }
                 }
-                sb.append("</span></div>");
+                sb.append("</span></div><div class=\"cmd-body\">");
+                sb.append("<span class=\"cmd-label\">name</span><code class=\"code\">").append(esc(command.name)).append("</code>");
                 if (command.arguments != null && !command.arguments.isEmpty()) {
-                    sb.append("<div class=\"muted\">arguments</div><ul>");
+                    sb.append("<span class=\"cmd-label\">arguments</span><div class=\"args\">");
+                    int k = 1;
                     for (String arg : command.arguments) {
-                        sb.append("<li><code>").append(esc(arg)).append("</code></li>");
+                        sb.append("<div class=\"arg\"><span class=\"arg-i\">").append(k++).append("</span>")
+                          .append("<code class=\"code\">").append(esc(arg)).append("</code></div>");
                     }
-                    sb.append("</ul>");
+                    sb.append("</div>");
                 }
-                sb.append("</div>");
+                sb.append("</div></section>");
             }
         }
+
         if (aRawYaml != null) {
-            sb.append("<details class=\"raw\"><summary>raw YAML</summary><pre>").append(esc(aRawYaml)).append("</pre></details>");
+            sb.append("<div id=\"alias-raw\" class=\"raw-card\" hidden><pre>").append(esc(aRawYaml)).append("</pre></div>");
         }
         return sb.toString();
     }

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -11,6 +11,14 @@
             --bg: #f4f5f7; --card: #ffffff; --fg: #1c1e21; --muted: #6b7280;
             --border: #e2e4e8; --accent: #2563eb; --ok: #15803d; --warn: #b45309; --bad: #b91c1c;
             --track: #eceef1; --fill: #2563eb;
+            /* derived from the base vars so both light and dark themes adapt */
+            --card-head:   color-mix(in srgb, var(--card) 55%, var(--bg));
+            --code-bg:     color-mix(in srgb, var(--bg) 92%, #000);
+            --code-border: color-mix(in srgb, var(--border) 85%, var(--fg));
+            --chip-border: color-mix(in srgb, var(--border) 82%, var(--fg));
+            --hover-border:color-mix(in srgb, var(--border) 78%, var(--fg));
+            --label:       color-mix(in srgb, var(--muted) 78%, var(--bg));
+            --argnum:      color-mix(in srgb, var(--muted) 58%, var(--bg));
         }
         @media (prefers-color-scheme: dark) {
             :root {
@@ -96,17 +104,63 @@
         .cfg-group:first-child { margin-top: 0; }
 
         /* aliases screen */
-        .aliases-layout { display: flex; gap: 16px; align-items: flex-start; flex-wrap: wrap; }
-        .aliases-list-pane { flex: 0 0 200px; }
-        #alias-detail { flex: 1 1 320px; }
-        .alias-list { display: flex; flex-direction: column; gap: 6px; }
+        .aliases-layout { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 16px; align-items: start; }
+        .aliases-list-pane { min-width: 0; }
+        @media (max-width: 720px) { .aliases-layout { grid-template-columns: 1fr; } }
+
+        .alias-side { background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+                      display: flex; flex-direction: column; overflow: hidden; position: sticky; top: 24px; }
+        @media (max-width: 720px) { .alias-side { position: static; } }
+        .alias-side-head { padding: 12px; border-bottom: 1px solid var(--border); display: flex; flex-direction: column; gap: 10px; }
+        .alias-side-row { display: flex; align-items: center; justify-content: space-between; }
+        .alias-side-title { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); font-weight: 700; }
+        .alias-count { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums;
+                       background: var(--track); padding: 1px 7px; border-radius: 999px; }
+        .alias-filter { box-sizing: border-box; width: 100%; padding: 7px 10px; border-radius: 8px;
+                        border: 1px solid var(--border); background: var(--bg); color: var(--fg); font: inherit; font-size: 13px; outline: none; }
+        .alias-filter:focus { border-color: var(--accent); }
+        .alias-list { padding: 8px; display: flex; flex-direction: column; gap: 4px; max-height: calc(100vh - 220px); overflow-y: auto; }
+        @media (max-width: 720px) { .alias-list { max-height: none; } }
         .alias-item { text-align: left; padding: 8px 10px; border-radius: 8px; cursor: pointer; font: inherit;
-                      color: var(--fg); background: var(--card); border: 1px solid var(--border); }
-        .alias-item:hover { border-color: var(--accent); }
-        .alias-cmd { border: 1px solid var(--border); border-radius: 8px; padding: 10px; margin-bottom: 10px; }
-        .chip { display: inline-block; padding: 1px 8px; margin: 0 4px 4px 0; border-radius: 999px; font-size: 12px; background: var(--track); }
-        .raw { margin-top: 8px; }
-        pre { overflow-x: auto; background: var(--track); padding: 10px; border-radius: 8px; font-size: 12px; }
+                      display: flex; flex-direction: column; gap: 2px; border: 1px solid transparent; background: transparent;
+                      transition: border-color .12s ease; }
+        .alias-item:hover { border-color: var(--hover-border); }
+        .alias-item.active { background: var(--track); border-color: var(--accent); }
+        .alias-name { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px;
+                      overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .alias-sub { color: var(--argnum); font-size: 11px; font-variant-numeric: tabular-nums; }
+        .alias-nomatch { display: none; color: var(--label); font-size: 12px; padding: 8px 10px; }
+
+        .alias-detail { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+        .alias-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+        .alias-title { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 19px; font-weight: 600; }
+        .alias-rawbtn { padding: 5px 12px; border-radius: 7px; cursor: pointer; font: inherit; font-size: 12px; font-weight: 600;
+                        color: var(--muted); background: transparent; border: 1px solid var(--border);
+                        transition: border-color .12s ease, color .12s ease; }
+        .alias-rawbtn:hover { color: var(--fg); border-color: var(--hover-border); }
+        .cmd-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+        .cmd-head { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-bottom: 1px solid var(--border);
+                    background: var(--card-head); flex-wrap: wrap; }
+        .cmd-num { width: 20px; height: 20px; flex: 0 0 auto; border-radius: 6px; background: var(--border); color: var(--muted);
+                   font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; font-variant-numeric: tabular-nums; }
+        .cmd-label { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--label); font-weight: 700; }
+        .chips { display: flex; flex-wrap: wrap; gap: 4px; }
+        .chip { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 1px 9px; border-radius: 999px;
+                background: var(--track); border: 1px solid var(--chip-border); color: var(--fg); }
+        .cmd-body { padding: 12px; display: grid; grid-template-columns: 76px minmax(0, 1fr); gap: 10px 12px; align-items: start; }
+        .cmd-body .cmd-label { padding-top: 5px; }
+        .code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; color: var(--fg);
+                background: var(--code-bg); border: 1px solid var(--code-border); border-radius: 7px; padding: 5px 10px;
+                overflow-x: auto; white-space: pre; }
+        .args { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+        .arg { display: flex; gap: 8px; align-items: baseline; min-width: 0; }
+        .arg-i { flex: 0 0 auto; color: var(--argnum); font-size: 11px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                 font-variant-numeric: tabular-nums; padding-top: 1px; }
+        .arg .code { flex: 1 1 auto; min-width: 0; padding: 4px 10px; }
+        .raw-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 12px; }
+        .raw-card pre { margin: 0; overflow-x: auto; background: var(--code-bg); border: 1px solid var(--code-border); padding: 12px;
+                        border-radius: 8px; font-size: 12px; line-height: 1.65; color: var(--fg);
+                        font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     </style>
 </head>
 <body hx-ext="sse" sse-connect="{{BASE}}/events">
@@ -148,7 +202,7 @@
     <section id="screen-aliases" class="screen" hidden>
         <div class="aliases-layout">
             <div class="aliases-list-pane" hx-get="{{BASE}}/aliases" hx-trigger="load"><span class="muted">loading&hellip;</span></div>
-            <div id="alias-detail" class="card"><span class="muted">select an alias&hellip;</span></div>
+            <div id="alias-detail" class="alias-detail"><span class="muted">select an alias&hellip;</span></div>
         </div>
     </section>
 
@@ -175,6 +229,34 @@
                         document.getElementById(screens[key]).hidden = (key !== want);
                     });
                 });
+            });
+        })();
+
+        (function () {
+            var scr = document.getElementById('screen-aliases');
+            if (!scr) { return; }
+            // client-side filter of the alias list by name substring
+            scr.addEventListener('input', function (e) {
+                if (!e.target.classList || !e.target.classList.contains('alias-filter')) { return; }
+                var q = e.target.value.trim().toLowerCase();
+                var items = scr.querySelectorAll('.alias-item');
+                var shown = 0;
+                items.forEach(function (it) {
+                    var nameEl = it.querySelector('.alias-name');
+                    var name = (nameEl ? nameEl.textContent : '').toLowerCase();
+                    var match = !q || name.indexOf(q) >= 0;
+                    it.style.display = match ? '' : 'none';
+                    if (match) { shown++; }
+                });
+                var nomatch = scr.querySelector('.alias-nomatch');
+                if (nomatch) { nomatch.style.display = (shown === 0 && items.length > 0) ? 'block' : 'none'; }
+            });
+            // highlight the selected alias
+            scr.addEventListener('click', function (e) {
+                var btn = e.target.closest ? e.target.closest('.alias-item') : null;
+                if (!btn) { return; }
+                scr.querySelectorAll('.alias-item.active').forEach(function (a) { a.classList.remove('active'); });
+                btn.classList.add('active');
             });
         })();
     </script>

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -20,8 +20,14 @@
             --label:       color-mix(in srgb, var(--muted) 78%, var(--bg));
             --argnum:      color-mix(in srgb, var(--muted) 58%, var(--bg));
         }
+        /* dark palette — applied on explicit toggle (data-theme=dark) or by OS unless the user forced light */
+        :root[data-theme="dark"] {
+            --bg: #16181d; --card: #1f232b; --fg: #e6e8eb; --muted: #9aa1ab;
+            --border: #2c313b; --accent: #60a5fa; --ok: #4ade80; --warn: #fbbf24; --bad: #f87171;
+            --track: #2c313b; --fill: #60a5fa;
+        }
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme="light"]) {
                 --bg: #16181d; --card: #1f232b; --fg: #e6e8eb; --muted: #9aa1ab;
                 --border: #2c313b; --accent: #60a5fa; --ok: #4ade80; --warn: #fbbf24; --bad: #f87171;
                 --track: #2c313b; --fill: #60a5fa;
@@ -95,6 +101,7 @@
         .tab { padding: 6px 14px; border-radius: 8px; cursor: pointer; font: inherit; font-weight: 600;
                color: var(--muted); background: transparent; border: 1px solid var(--border); }
         .tab.active { color: var(--fg); background: var(--card); border-color: var(--accent); }
+        .theme-toggle { margin-left: auto; }
         .screen { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
         .screen[hidden] { display: none; }
         #screen-config, #screen-aliases { overflow-y: auto; }
@@ -121,7 +128,7 @@
         .alias-filter:focus { border-color: var(--accent); }
         .alias-list { padding: 8px; display: flex; flex-direction: column; gap: 4px; max-height: calc(100vh - 220px); overflow-y: auto; }
         @media (max-width: 720px) { .alias-list { max-height: none; } }
-        .alias-item { text-align: left; padding: 8px 10px; border-radius: 8px; cursor: pointer; font: inherit;
+        .alias-item { text-align: left; padding: 8px 10px; border-radius: 8px; cursor: pointer; font: inherit; color: var(--fg);
                       display: flex; flex-direction: column; gap: 2px; border: 1px solid transparent; background: transparent;
                       transition: border-color .12s ease; }
         .alias-item:hover { border-color: var(--hover-border); }
@@ -170,6 +177,7 @@
         <button class="tab active" data-screen="live">Live</button>
         <button class="tab" data-screen="config">Config</button>
         <button class="tab" data-screen="aliases">Aliases</button>
+        <button class="tab theme-toggle" id="theme-btn" type="button" title="Toggle light / dark theme" aria-label="Toggle theme">&#9680;</button>
     </nav>
 
     <section id="screen-live" class="screen">
@@ -207,6 +215,30 @@
     </section>
 
     <script>
+        (function () {
+            var root = document.documentElement;
+            var btn  = document.getElementById('theme-btn');
+            function effective() {
+                var t = root.getAttribute('data-theme');
+                if (t === 'light' || t === 'dark') { return t; }
+                return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+            }
+            function label() { if (btn) { btn.textContent = effective() === 'dark' ? '☾' : '☀'; } }
+            try {
+                var saved = localStorage.getItem('theme');
+                if (saved === 'light' || saved === 'dark') { root.setAttribute('data-theme', saved); }
+            } catch (e) { /* localStorage unavailable */ }
+            label();
+            if (btn) {
+                btn.addEventListener('click', function () {
+                    var next = effective() === 'dark' ? 'light' : 'dark';
+                    root.setAttribute('data-theme', next);
+                    try { localStorage.setItem('theme', next); } catch (e) { /* ignore */ }
+                    label();
+                });
+            }
+        })();
+
         (function () {
             var banner = document.getElementById('sse-status');
             var body   = document.body;

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -157,15 +157,23 @@ public class DashboardViewTest {
     }
 
     @Test
-    public void aliasListRendersButtonsWithHxGet() {
-        String html = DashboardView.aliasList(List.of("deploy-demo"), "/deploy/dashboard");
+    public void aliasSidebarRendersItemsWithHxGetAndCount() {
+        String html = DashboardView.aliasSidebar(List.of(new DashboardView.AliasInfo("deploy-demo", 2)), "/deploy/dashboard");
         assertTrue(html, html.contains("deploy-demo"));
-        assertTrue(html, html.contains("hx-get=\"/deploy/dashboard/aliases/deploy-demo\""));
+        assertTrue(html, html.contains("2 commands"));
+        assertTrue(html, html.contains("hx-get=\"/deploy/dashboard/alias?name=deploy-demo\""));
     }
 
     @Test
-    public void aliasListEmptyShowsPlaceholder() {
-        assertTrue(DashboardView.aliasList(new ArrayList<>(), "/x").contains("no aliases"));
+    public void aliasSidebarSingleCommandIsSingular() {
+        String html = DashboardView.aliasSidebar(List.of(new DashboardView.AliasInfo("solo", 1)), "/x");
+        assertTrue(html, html.contains("1 command"));
+        assertFalse(html, html.contains("1 commands"));
+    }
+
+    @Test
+    public void aliasSidebarEmptyShowsPlaceholder() {
+        assertTrue(DashboardView.aliasSidebar(new ArrayList<>(), "/x").contains("no aliases"));
     }
 
     @Test
@@ -184,7 +192,8 @@ public class DashboardViewTest {
         assertTrue(html, html.contains("agent-2"));
         assertTrue(html, html.contains("&lt;hi&gt;"));
         assertFalse(html, html.contains("<hi>"));
-        assertTrue(html, html.contains("raw YAML"));
+        assertTrue(html, html.contains("show yaml"));
+        assertTrue(html, html.contains("cmd-card"));
     }
 
     @Test


### PR DESCRIPTION
## Что
Редизайн вкладки **Aliases** по дизайн-хендоффу (стек не менялся — **htmx + серверный HTML**).

- **Двухколоночный layout** (`280px minmax(0,1fr)`, на < 720px — одна колонка).
- **Сайдбар** (`GET /deploy/dashboard/aliases`): заголовок «Aliases» + пилюля-счётчик + инпут `filter…`; список `.alias-item` (имя + «N commands»). Фильтр — клиентский (подстрока в имени), выбранный элемент подсвечивается.
- **Детали** — эндпоинт сменился на **`GET /deploy/dashboard/alias?name=<alias>`**: заголовок + тоггл «show/hide yaml»; на каждую команду — карточка (номер + `agents`-чипы, `name` в code, нумерованные `arguments`); показываются **только** поля `agents`, `name`, `arguments`; плюс блок raw YAML, скрытый по умолчанию.
- **Цвета** — через существующие CSS-переменные (`--bg/--card/--border/--fg/--muted/--accent/--track`) + несколько производных через `color-mix`, поэтому **светлая тема осталась рабочей** (в предпросмотре есть тумблер).

## Проверка
`mvn -B -ntp verify` под JDK 21 → `BUILD SUCCESS`. `DashboardViewTest` обновлён (`aliasSidebar` с hx-get `/alias?name=…`, счётчик commands, «show yaml», экранирование); `FullEnvironmentTest` теперь дёргает `/deploy/dashboard/alias?name=deploy-demo`. Отправлен рендер-предпросмотр (светлая/тёмная).

Дизайн-пакет `design_handoff_aliases/` в коммит не входит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)