### PR TITLE
feat(dashboard): redesign Live and Config tabs

### DIFF
--- a/integration-test/src/test/java/io/pne/deploy/tests/DashboardHttpTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/DashboardHttpTest.java
@@ -65,9 +65,9 @@ public class DashboardHttpTest {
             HttpResponse<InputStream> events = client.send(get("/deploy/dashboard/events"), ofInputStream());
             assertEquals(200, events.statusCode());
             assertTrue(events.headers().firstValue("content-type").orElse("").startsWith("text/event-stream"));
-            String frames = readUntil(events.body(), "event: latency"); // last event in a snapshot
+            String frames = readUntil(events.body(), "event: logs"); // last event in a snapshot
             assertTrue("SSE should push an 'agents' event, got: " + frames, frames.contains("event: agents"));
-            assertTrue("SSE should push a 'latency' event, got: " + frames, frames.contains("event: latency"));
+            assertTrue("SSE should push a merged 'delivery' event, got: " + frames, frames.contains("event: delivery"));
             assertTrue("SSE frames should carry data lines", frames.contains("data:"));
         } finally {
             server.stop();

--- a/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/FullEnvironmentTest.java
@@ -31,6 +31,8 @@ public class FullEnvironmentTest {
             String frames = env.readDashboardEvents("deployed", 10_000);
             assertTrue("dashboard should stream an 'logs' event, got: " + frames, frames.contains("event: logs"));
             assertTrue("agent echo output should appear in the logs card, got: " + frames, frames.contains("deployed"));
+            // queues + latency are merged into one 'delivery' fragment
+            assertTrue("dashboard should stream a 'delivery' event, got: " + frames, frames.contains("event: delivery"));
 
             // Config screen lists env vars but masks secrets.
             String config = env.httpGet("/deploy/dashboard/config");

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -60,6 +60,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final List<StartupConfigReport.Entry> configEntries;
     private final File                         aliasesDir;
     private final long                         refreshMs;
+    private final String                       redmineBaseUrl; // for linking issue ids on the task card
 
     private final String basePath;
     private final String eventsPath;
@@ -97,6 +98,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.configEntries      = aConfigEntries;
         this.aliasesDir         = aAliasesDir;
         this.refreshMs          = aRefreshMs;
+        this.redmineBaseUrl     = findConfig(aConfigEntries, "REDMINE_URL");
 
         this.basePath    = normalize(aBasePath);
         this.eventsPath  = basePath + "/events";
@@ -190,6 +192,19 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         aRequest.response().putHeader("Content-Type", aContentType).end(aBody);
     }
 
+    /** Effective value of a non-masked config entry by name, or "" when absent or masked. */
+    private static String findConfig(List<StartupConfigReport.Entry> aEntries, String aName) {
+        if (aEntries == null) {
+            return "";
+        }
+        for (StartupConfigReport.Entry entry : aEntries) {
+            if (aName.equals(entry.name()) && !entry.masked()) {
+                return entry.value() == null ? "" : entry.value();
+            }
+        }
+        return "";
+    }
+
     /** POST {base}/issue with form field issue_id -> enqueue, then return the refreshed issues fragment. */
     private void handleIssue(HttpServerRequest aRequest) {
         if (aRequest.method() != HttpMethod.POST) {
@@ -249,10 +264,9 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             writeEvent(aResponse, "service", DashboardView.service(
                     ManagementFactory.getRuntimeMXBean().getUptime(), heapUsed, runtime.maxMemory(), agentSnapshot.size()));
             writeEvent(aResponse, "agents", DashboardView.agents(agentSnapshot));
-            writeEvent(aResponse, "status", DashboardView.status(taskStatusSupplier.get()));
+            writeEvent(aResponse, "status", DashboardView.status(taskStatusSupplier.get(), redmineBaseUrl));
             writeEvent(aResponse, "issues", DashboardView.issues(issueSnapshot));
-            writeEvent(aResponse, "queues", DashboardView.queues(queues));
-            writeEvent(aResponse, "latency", DashboardView.latency(latencySnapshot()));
+            writeEvent(aResponse, "delivery", DashboardView.delivery(queues, latencySnapshot()));
             writeEvent(aResponse, "logs", DashboardView.logs(logBuffer.snapshot(50)));
             return true;
         } catch (RuntimeException e) {

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -25,109 +25,116 @@ public final class DashboardView {
 
     private static final DateTimeFormatter LOG_TIME = DateTimeFormatter.ofPattern("HH:mm:ss");
 
-    /** Connected agent ids. */
+    /** Connected agent ids, rendered as the AGENTS block (label + count pill + chips) of the task card. */
     public static String agents(Set<String> aAgents) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<div class=\"kv\"><span>Connected</span><b>").append(aAgents.size()).append("</b></div>");
+        sb.append("<div class=\"agents-head\"><span class=\"cmd-label\">agents</span>")
+          .append("<span class=\"agents-count\">").append(aAgents.size()).append(" connected</span></div>");
         if (aAgents.isEmpty()) {
             sb.append("<p class=\"muted\">no agents connected</p>");
         } else {
-            sb.append("<ul>");
+            sb.append("<div class=\"chips\">");
             for (String agent : new java.util.TreeSet<>(aAgents)) { // alphabetical
-                sb.append("<li><code>").append(esc(agent)).append("</code></li>");
+                sb.append("<span class=\"chip\">").append(esc(agent)).append("</span>");
             }
-            sb.append("</ul>");
+            sb.append("</div>");
         }
         return sb.toString();
     }
 
-    /** The last task pushed by the execution listener (nullable). */
-    public static String status(TaskStatus aStatus) {
+    /** The last task pushed by the execution listener (nullable). {@code aRedmineBaseUrl} links the issue id. */
+    public static String status(TaskStatus aStatus, String aRedmineBaseUrl) {
         if (aStatus == null) {
-            return "<p class=\"muted\">idle &mdash; no task running</p>";
+            return "<div class=\"task-head\"><span class=\"cmd-label\">current task</span></div>"
+                    + "<p class=\"muted\">idle &mdash; no task running</p>";
         }
         StringBuilder sb = new StringBuilder();
-        sb.append("<div class=\"kv\"><span>State</span>").append(statePill(aStatus.getTaskState())).append("</div>");
-        sb.append("<div class=\"kv\"><span>Task id</span><b><code>").append(esc(aStatus.getTaskId())).append("</code></b></div>");
-        sb.append("<div class=\"kv\"><span>Issue</span><b>").append(aStatus.getIssueId()).append("</b></div>");
+        sb.append("<div class=\"task-head\"><span class=\"cmd-label\">current task</span>")
+          .append(stateBadge(aStatus.getTaskState())).append("</div>");
         if (aStatus.getTaskLine() != null) {
-            sb.append("<div class=\"kv\"><span>Task</span><b><code>").append(esc(aStatus.getTaskLine())).append("</code></b></div>");
+            sb.append("<div class=\"task-name\"><code>").append(esc(aStatus.getTaskLine())).append("</code></div>");
         }
+        sb.append("<div class=\"task-meta\">")
+          .append("<div class=\"meta-col\"><span class=\"cmd-label\">task id</span>")
+          .append("<code class=\"meta-val\">").append(esc(aStatus.getTaskId())).append("</code></div>")
+          .append("<div class=\"meta-col\"><span class=\"cmd-label\">issue</span>")
+          .append(issueLink(aStatus.getIssueId(), aRedmineBaseUrl)).append("</div>")
+          .append("</div>");
         TaskState state = aStatus.getTaskState();
         if (state != null && state.getErrorMessage() != null) {
-            sb.append("<p class=\"pill bad\">").append(esc(state.getErrorMessage())).append("</p>");
+            sb.append("<p class=\"task-err\">").append(esc(state.getErrorMessage())).append("</p>");
         }
         return sb.toString();
+    }
+
+    private static String issueLink(long aIssueId, String aRedmineBaseUrl) {
+        String label = "#" + aIssueId;
+        if (aRedmineBaseUrl == null || aRedmineBaseUrl.isBlank()) {
+            return "<code class=\"meta-val\">" + label + "</code>";
+        }
+        String base = aRedmineBaseUrl.endsWith("/")
+                ? aRedmineBaseUrl.substring(0, aRedmineBaseUrl.length() - 1) : aRedmineBaseUrl;
+        return "<a class=\"meta-val issue-link\" href=\"" + esc(base) + "/issues/" + aIssueId
+                + "\" target=\"_blank\" rel=\"noopener\">" + label + "</a>";
     }
 
     /** Pending Redmine issue ids waiting to be processed. */
     public static String issues(Collection<Long> aIssues) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<div class=\"kv\"><span>Pending</span><b>").append(aIssues.size()).append("</b></div>");
+        sb.append("<div class=\"issues-count\">pending <b>").append(aIssues.size()).append("</b></div>");
         if (aIssues.isEmpty()) {
-            sb.append("<p class=\"muted\">queue is empty</p>");
+            sb.append("<div class=\"issues-empty\">queue is empty</div>");
         } else {
-            sb.append("<ul>");
+            sb.append("<div class=\"issues-list\">");
             for (Long id : aIssues) {
-                sb.append("<li><code>#").append(id).append("</code></li>");
+                sb.append("<div class=\"issue-row\"><code>#").append(id).append("</code></div>");
             }
-            sb.append("</ul>");
+            sb.append("</div>");
         }
         return sb.toString();
     }
 
-    /** Durable delivery queues (telegram, redmine) with their spool counters. */
-    public static String queues(Map<String, PersistentSpool> aQueues) {
+    /** Delivery queues + send-latency merged into one table: one row per queue, all values as numbers. */
+    public static String delivery(Map<String, PersistentSpool> aQueues, Map<String, LatencyStat> aLatency) {
         if (aQueues.isEmpty()) {
             return "<p class=\"muted\">no queues</p>";
         }
         StringBuilder sb = new StringBuilder();
-        sb.append("<div class=\"tablewrap\"><table><thead><tr><th>queue</th>")
-          .append("<th class=\"num\">pending</th><th class=\"num\">dead</th>")
-          .append("<th class=\"num\">sent</th><th class=\"num\" title=\"dead-lettered\">DLQ</th></tr></thead><tbody>");
-        int maxPending = 0;
+        sb.append("<div class=\"delivery-wrap\"><table class=\"delivery\"><thead><tr>")
+          .append("<th class=\"l\">queue</th>")
+          .append("<th>pending</th><th>dead</th><th>sent</th><th>dlq</th>")
+          .append("<th class=\"n\">n</th><th>mean</th><th>p50</th><th>p95</th><th>p99</th><th>max</th>")
+          .append("</tr></thead><tbody>");
         for (Map.Entry<String, PersistentSpool> entry : aQueues.entrySet()) {
             PersistentSpool spool = entry.getValue();
-            maxPending = Math.max(maxPending, spool.size());
-            sb.append("<tr><td>").append(esc(entry.getKey())).append("</td>")
-              .append("<td class=\"num\">").append(spool.size()).append("</td>")
-              .append("<td class=\"num\">").append(spool.deadSize()).append("</td>")
-              .append("<td class=\"num\">").append(spool.sentCount()).append("</td>")
-              .append("<td class=\"num\">").append(spool.deadLetterCount()).append("</td></tr>");
+            int  pending = spool.size();
+            long dead    = spool.deadSize();
+            long dlq     = spool.deadLetterCount();
+            sb.append("<tr><td class=\"l\">").append(esc(entry.getKey())).append("</td>")
+              .append(numCell(pending, pending > 0 ? "warn" : null))
+              .append(numCell(dead, dead > 0 ? "bad" : null))
+              .append(numCell(spool.sentCount(), null))
+              .append(numCell(dlq, dlq > 0 ? "bad" : null));
+            LatencyStat stat = aLatency == null ? null : aLatency.get(entry.getKey());
+            if (stat == null || stat.count() == 0) {
+                sb.append("<td class=\"n\">&mdash;</td><td>&mdash;</td><td>&mdash;</td>")
+                  .append("<td>&mdash;</td><td>&mdash;</td><td>&mdash;</td>");
+            } else {
+                sb.append("<td class=\"n\">").append(stat.count()).append("</td>")
+                  .append("<td>").append(formatMs(stat.meanMs())).append("</td>")
+                  .append("<td>").append(formatMs(stat.p50Ms())).append("</td>")
+                  .append("<td>").append(formatMs(stat.p95Ms())).append("</td>")
+                  .append("<td>").append(formatMs(stat.p99Ms())).append("</td>")
+                  .append("<td>").append(formatMs(stat.maxMs())).append("</td>");
+            }
+            sb.append("</tr>");
         }
         sb.append("</tbody></table></div>");
-
-        // depth bars (pending), scaled to the busiest queue
-        sb.append("<div class=\"bars\">");
-        for (Map.Entry<String, PersistentSpool> entry : aQueues.entrySet()) {
-            int pending = entry.getValue().size();
-            double fraction = maxPending == 0 ? 0.0 : (double) pending / maxPending;
-            sb.append(barRow(esc(entry.getKey()), Integer.toString(pending), fraction));
-        }
-        sb.append("</div>");
         return sb.toString();
     }
 
-    /** Per-queue send-latency percentiles as horizontal bars scaled to each queue's max. */
-    public static String latency(Map<String, LatencyStat> aStats) {
-        if (aStats.isEmpty()) {
-            return "<p class=\"muted\">no data</p>";
-        }
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, LatencyStat> entry : aStats.entrySet()) {
-            LatencyStat stat = entry.getValue();
-            sb.append("<div class=\"lat\"><div class=\"kv\"><span><b>").append(esc(entry.getKey())).append("</b></span>")
-              .append("<span class=\"muted\">n=").append(stat.count())
-              .append(", mean ").append(formatMs(stat.meanMs())).append("</span></div>");
-            double scale = stat.maxMs() <= 0 ? 1.0 : stat.maxMs();
-            sb.append("<div class=\"bars\">");
-            sb.append(barRow("p50", formatMs(stat.p50Ms()), stat.p50Ms() / scale));
-            sb.append(barRow("p95", formatMs(stat.p95Ms()), stat.p95Ms() / scale));
-            sb.append(barRow("p99", formatMs(stat.p99Ms()), stat.p99Ms() / scale));
-            sb.append(barRow("max", formatMs(stat.maxMs()), 1.0));
-            sb.append("</div></div>");
-        }
-        return sb.toString();
+    private static String numCell(long aValue, String aClass) {
+        return aClass == null ? "<td>" + aValue + "</td>" : "<td class=\"" + aClass + "\">" + aValue + "</td>";
     }
 
     /** Recent agent command-output log lines (newest first). Connect/disconnect are not shown. */
@@ -139,9 +146,9 @@ public final class DashboardView {
         sb.append("<div class=\"logbox\">");
         for (AgentLogBuffer.LogLine line : aLines) {
             String time = LOG_TIME.format(Instant.ofEpochMilli(line.epochMs()).atZone(ZoneId.systemDefault()));
-            sb.append("<div class=\"logline\"><span class=\"muted\">").append(time).append("</span> ")
-              .append("<code>#").append(esc(shortId(line.commandId()))).append("</code> ")
-              .append(esc(line.message()))
+            sb.append("<div class=\"logline\"><span class=\"log-time\">").append(time).append("</span>")
+              .append("<code class=\"log-id\">#").append(esc(shortId(line.commandId()))).append("</code>")
+              .append("<span class=\"log-msg\">").append(esc(line.message())).append("</span>")
               .append("</div>");
         }
         sb.append("</div>");
@@ -155,32 +162,94 @@ public final class DashboardView {
         return aCommandId.length() > 8 ? aCommandId.substring(0, 8) : aCommandId;
     }
 
-    /** Grouped table of startup config parameters (secrets already masked in the entries). */
+    /**
+     * Full Config screen: a filter toolbar plus one card per group with a filterable grid of rows. Secrets are
+     * already masked in the entries and never carry the real value. The client filters the rendered rows.
+     */
     public static String config(List<StartupConfigReport.Entry> aEntries) {
         if (aEntries.isEmpty()) {
             return "<p class=\"muted\">no config</p>";
         }
-        StringBuilder sb = new StringBuilder();
-        String currentGroup = null;
-        for (StartupConfigReport.Entry entry : aEntries) {
-            if (!entry.group().equals(currentGroup)) {
-                if (currentGroup != null) {
-                    sb.append("</tbody></table></div>");
-                }
-                currentGroup = entry.group();
-                sb.append("<h3 class=\"cfg-group\">").append(esc(currentGroup)).append("</h3>");
-                sb.append("<div class=\"tablewrap\"><table><thead><tr>")
-                  .append("<th>variable</th><th>value</th><th>default</th></tr></thead><tbody>");
+        int overridden = 0;
+        for (StartupConfigReport.Entry e : aEntries) {
+            if (isOverridden(e)) {
+                overridden++;
             }
-            sb.append("<tr><td><code>").append(esc(entry.name())).append("</code></td>")
-              .append("<td>").append(esc(entry.value()));
-            if (!entry.isDefault()) {
-                sb.append(" <span class=\"pill warn\">overridden</span>");
-            }
-            sb.append("</td><td class=\"muted\"><code>").append(esc(entry.def())).append("</code></td></tr>");
         }
-        sb.append("</tbody></table></div>");
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div class=\"cfg-toolbar\">")
+          .append("<input class=\"cfg-filter\" type=\"text\" placeholder=\"filter variables&hellip;\" autocomplete=\"off\" spellcheck=\"false\">")
+          .append("<button class=\"cfg-toggle\" type=\"button\">overridden only</button>")
+          .append("<span class=\"cfg-summary\">").append(aEntries.size()).append(" variables &middot; ")
+          .append(overridden).append(" overridden</span></div>");
+
+        Map<String, List<StartupConfigReport.Entry>> byGroup = new java.util.LinkedHashMap<>();
+        for (StartupConfigReport.Entry e : aEntries) {
+            byGroup.computeIfAbsent(e.group(), k -> new java.util.ArrayList<>()).add(e);
+        }
+        for (Map.Entry<String, List<StartupConfigReport.Entry>> group : byGroup.entrySet()) {
+            List<StartupConfigReport.Entry> rows = group.getValue();
+            int groupOvr = 0;
+            for (StartupConfigReport.Entry e : rows) {
+                if (isOverridden(e)) {
+                    groupOvr++;
+                }
+            }
+            sb.append("<section class=\"cfg-card\"><div class=\"cfg-card-head\">")
+              .append("<span class=\"cfg-group-label\">").append(esc(group.getKey())).append("</span>")
+              .append("<span class=\"cfg-count\" data-total=\"").append(rows.size()).append("\">")
+              .append(rows.size()).append(" of ").append(rows.size()).append("</span>");
+            if (groupOvr > 0) {
+                sb.append("<span class=\"cfg-ovr\">").append(groupOvr).append(" overridden</span>");
+            }
+            sb.append("</div><div class=\"cfg-grid\">")
+              .append("<div class=\"cfg-row cfg-th\"><span>variable</span><span>value</span><span>default</span></div>");
+            for (StartupConfigReport.Entry e : rows) {
+                boolean ovr   = isOverridden(e);
+                String  value = e.masked() ? "••••" : e.value();
+                String  def   = e.def() == null || e.def().isEmpty() ? "—" : e.def();
+                sb.append("<div class=\"cfg-row\" data-var=\"").append(esc(e.name().toLowerCase()))
+                  .append("\" data-value=\"").append(esc(e.value() == null ? "" : e.value().toLowerCase()))
+                  .append("\" data-overridden=\"").append(ovr).append("\">")
+                  .append("<span class=\"cfg-var\"><span class=\"cfg-dot").append(ovr ? " on" : "").append("\"></span>")
+                  .append("<span class=\"cfg-name\">").append(esc(e.name())).append("</span></span>")
+                  .append("<span class=\"cfg-value\"><span class=\"v-").append(valueKind(e)).append("\">")
+                  .append(esc(value)).append("</span>");
+                if (e.masked() && isSecretSet(e)) {
+                    sb.append("<span class=\"cfg-set\">set</span>");
+                }
+                sb.append("</span><span class=\"cfg-def\">").append(esc(def)).append("</span></div>");
+            }
+            sb.append("</div></section>");
+        }
+        sb.append("<div class=\"cfg-empty\" hidden>nothing matches the current filter</div>");
         return sb.toString();
+    }
+
+    private static boolean isOverridden(StartupConfigReport.Entry aEntry) {
+        return aEntry.masked() ? isSecretSet(aEntry) : !aEntry.isDefault();
+    }
+
+    private static boolean isSecretSet(StartupConfigReport.Entry aEntry) {
+        return aEntry.value() != null && aEntry.value().contains("(set)");
+    }
+
+    /** Coarse value classification for colour-coding: secret / num / bool / path / str. */
+    private static String valueKind(StartupConfigReport.Entry aEntry) {
+        if (aEntry.masked()) {
+            return "secret";
+        }
+        String v = aEntry.value() == null ? "" : aEntry.value().trim();
+        if (v.matches("-?\\d+")) {
+            return "num";
+        }
+        if (v.equalsIgnoreCase("true") || v.equalsIgnoreCase("false")) {
+            return "bool";
+        }
+        if (v.startsWith("/") || v.startsWith("./") || v.startsWith("../")) {
+            return "path";
+        }
+        return "str";
     }
 
     /** One alias in the sidebar list: name + number of commands. */
@@ -256,16 +325,6 @@ public final class DashboardView {
         return sb.toString();
     }
 
-    /** One horizontal bar: label, a filled track (fraction clamped to [0,1]) and a value caption. */
-    static String barRow(String aLabel, String aValueText, double aFraction) {
-        long pct = Math.round(Math.max(0.0, Math.min(1.0, aFraction)) * 100);
-        return "<div class=\"barrow\">"
-                + "<span class=\"barlabel\">" + aLabel + "</span>"
-                + "<span class=\"bartrack\"><span class=\"barfill\" style=\"width:" + pct + "%\"></span></span>"
-                + "<span class=\"barval\">" + aValueText + "</span>"
-                + "</div>";
-    }
-
     static String formatMs(double aMs) {
         if (aMs < 1.0) {
             return String.format("%.1f ms", aMs);
@@ -276,19 +335,16 @@ public final class DashboardView {
         return String.format("%.1f s", aMs / 1000.0);
     }
 
-    /** Coarse JVM/service vitals; values are passed in so the method stays deterministic. */
+    /** Coarse JVM/service vitals rendered as inline header metrics (uptime / heap / agents). */
     public static String service(long aUptimeMs, long aHeapUsed, long aHeapMax, int aAgentCount) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("<div class=\"kv\"><span>Uptime</span><b>").append(formatDuration(aUptimeMs)).append("</b></div>");
-        sb.append("<div class=\"kv\"><span>Heap</span><b>")
-          .append(formatBytes(aHeapUsed)).append(" / ").append(formatBytes(aHeapMax)).append("</b></div>");
-        sb.append("<div class=\"kv\"><span>Agents</span><b>").append(aAgentCount).append("</b></div>");
-        return sb.toString();
+        return "<span class=\"vital\">uptime <b>" + formatDuration(aUptimeMs) + "</b></span>"
+                + "<span class=\"vital\">heap <b>" + formatBytes(aHeapUsed) + " / " + formatBytes(aHeapMax) + "</b></span>"
+                + "<span class=\"vital\">agents <b>" + aAgentCount + "</b></span>";
     }
 
-    private static String statePill(TaskState aState) {
+    private static String stateBadge(TaskState aState) {
         if (aState == null || aState.getType() == null) {
-            return "<span class=\"pill\">unknown</span>";
+            return "<span class=\"badge\">unknown</span>";
         }
         String cls;
         switch (aState.getType()) {
@@ -296,7 +352,7 @@ public final class DashboardView {
             case ERROR:   cls = "bad";  break;
             default:      cls = "warn"; break; // RUNNING
         }
-        return "<span class=\"pill " + cls + "\">" + aState.getType() + "</span>";
+        return "<span class=\"badge " + cls + "\">" + aState.getType() + "</span>";
     }
 
     static String formatDuration(long aMs) {

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -19,6 +19,7 @@
             --hover-border:color-mix(in srgb, var(--border) 78%, var(--fg));
             --label:       color-mix(in srgb, var(--muted) 78%, var(--bg));
             --argnum:      color-mix(in srgb, var(--muted) 58%, var(--bg));
+            --row-border:  color-mix(in srgb, var(--border) 60%, var(--bg));
         }
         /* dark palette — applied on explicit toggle (data-theme=dark) or by OS unless the user forced light */
         :root[data-theme="dark"] {
@@ -39,62 +40,20 @@
             font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
             min-height: 100vh; display: flex; flex-direction: column;
         }
-        h1 { font-size: 20px; margin: 0 0 4px; }
-        .sub { color: var(--muted); margin: 0 0 20px; font-size: 13px; }
-        .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); flex: 0 0 auto; }
+        h1 { font-size: 20px; margin: 0 0 12px; }
         .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
-        .card h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 0 0 12px; }
-        .tablewrap { overflow-x: auto; }
-        table { width: 100%; border-collapse: collapse; }
-        .card table { font-size: 12px; }
-        th, td { text-align: left; padding: 4px 6px; border-bottom: 1px solid var(--border); white-space: nowrap; }
-        th { color: var(--muted); font-weight: 600; }
-        td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
-        ul { margin: 0; padding-left: 18px; }
+        .card.flush { padding: 0; overflow: hidden; }
         .muted { color: var(--muted); }
-        .kv { display: flex; justify-content: space-between; gap: 12px; padding: 3px 0; }
-        .kv b { font-weight: 600; }
         .pill { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; }
         .pill.ok { color: var(--ok); } .pill.warn { color: var(--warn); } .pill.bad { color: var(--bad); }
         code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+        .cmd-label { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--label); font-weight: 700; }
 
-        /* horizontal bars (queue depth, latency percentiles) */
-        .bars { margin-top: 8px; }
-        .lat + .lat { margin-top: 12px; }
-        .barrow { display: flex; align-items: center; gap: 8px; padding: 2px 0; }
-        .barlabel { flex: 0 0 44px; color: var(--muted); font-size: 12px; }
-        .bartrack { flex: 1 1 auto; height: 8px; background: var(--track); border-radius: 999px; overflow: hidden; }
-        .barfill { display: block; height: 100%; background: var(--fill); border-radius: 999px; }
-        .barval { flex: 0 0 auto; min-width: 56px; text-align: right; font-variant-numeric: tabular-nums; font-size: 12px; }
-
-        /* add-issue form */
-        .issue-form { display: flex; gap: 8px; margin-bottom: 12px; }
-        .issue-form input {
-            flex: 1 1 auto; min-width: 0; padding: 6px 8px; border-radius: 8px;
-            border: 1px solid var(--border); background: var(--bg); color: var(--fg);
-        }
-        .issue-form button {
-            padding: 6px 14px; border: 0; border-radius: 8px; cursor: pointer;
-            background: var(--accent); color: #fff; font-weight: 600;
-        }
-
-        /* SSE connection warning banner */
-        .banner {
-            margin: 0 0 16px; padding: 10px 14px; border-radius: 8px; font-weight: 600;
-            color: var(--warn);
-            background: color-mix(in srgb, var(--warn) 15%, transparent);
-            border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
-        }
-        .banner[hidden] { display: none; }
-
-        /* agent logs — full-width panel that fills the remaining height */
-        .logs-card { flex: 1 1 auto; display: flex; flex-direction: column; margin-top: 16px; min-height: 160px; }
-        .logs-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
-        .logbox { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
-        .logline {
-            font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
-            white-space: pre-wrap; word-break: break-word; padding: 1px 0;
-        }
+        /* card header bar (Delivery, Agent logs) */
+        .card-head { padding: 12px 16px; background: var(--card-head); border-bottom: 1px solid var(--border);
+                     display: flex; align-items: center; gap: 12px;
+                     font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--label); font-weight: 700; }
+        .card-inline-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 
         /* top menu + screens */
         .tabs { display: flex; gap: 8px; margin: 0 0 16px; flex: 0 0 auto; }
@@ -106,11 +65,156 @@
         .screen[hidden] { display: none; }
         #screen-config, #screen-aliases { overflow-y: auto; }
 
-        /* config screen */
-        .cfg-group { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 16px 0 8px; }
-        .cfg-group:first-child { margin-top: 0; }
+        /* SSE connection warning banner */
+        .banner {
+            margin: 0 0 16px; padding: 10px 14px; border-radius: 8px; font-weight: 600;
+            color: var(--warn);
+            background: color-mix(in srgb, var(--warn) 15%, transparent);
+            border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
+        }
+        .banner[hidden] { display: none; }
 
-        /* aliases screen */
+        /* ---- Live: header status line ---- */
+        .statusbar { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin: 0 0 16px; flex: 0 0 auto; }
+        .sse-ind { display: flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 600; color: var(--ok); }
+        .sse-ind.warn { color: var(--warn); }
+        .sse-ind .dot { width: 7px; height: 7px; border-radius: 999px; background: currentColor; }
+        .vitals { margin-left: auto; display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+                  font-size: 12px; color: var(--muted); }
+        .vitals .vital b { color: var(--fg); font-weight: 600; font-variant-numeric: tabular-nums; }
+
+        /* ---- Live: top row (current task | issues) ---- */
+        .live-top { display: grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr); gap: 16px;
+                    align-items: start; margin: 0 0 16px; flex: 0 0 auto; }
+        @media (max-width: 900px) { .live-top { grid-template-columns: 1fr; } }
+
+        .task-card { display: flex; flex-direction: column; gap: 14px; }
+        .task-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+        .badge { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
+                 padding: 2px 9px; border-radius: 999px; color: var(--muted); background: var(--track); }
+        .badge.ok   { color: var(--ok);   background: color-mix(in srgb, var(--ok) 16%, transparent);   border: 1px solid color-mix(in srgb, var(--ok) 40%, transparent); }
+        .badge.warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 16%, transparent); border: 1px solid color-mix(in srgb, var(--warn) 40%, transparent); }
+        .badge.bad  { color: var(--bad);  background: color-mix(in srgb, var(--bad) 16%, transparent);  border: 1px solid color-mix(in srgb, var(--bad) 40%, transparent); }
+        .task-name { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+        .task-name code { font-size: 22px; font-weight: 600; letter-spacing: -0.01em; }
+        .task-meta { display: flex; gap: 24px; flex-wrap: wrap; }
+        .meta-col { display: flex; flex-direction: column; gap: 2px; }
+        .meta-val { font-size: 12px; color: var(--fg); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+        a.issue-link { color: var(--accent); text-decoration: none; }
+        a.issue-link:hover { text-decoration: underline; }
+        .task-err { margin: 0; color: var(--bad); font-size: 12.5px; white-space: pre-wrap; word-break: break-word; }
+        .task-agents { border-top: 1px solid var(--border); padding-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+        .agents-head { display: flex; align-items: center; gap: 10px; }
+        .agents-count { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums;
+                        background: var(--track); padding: 1px 7px; border-radius: 999px; }
+        .chips { display: flex; flex-wrap: wrap; gap: 4px; }
+        .chip { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 1px 9px;
+                border-radius: 999px; background: var(--track); border: 1px solid var(--chip-border); color: var(--fg); }
+
+        /* issues card */
+        .issue-form { display: flex; gap: 8px; margin-bottom: 12px; }
+        .issue-form input {
+            flex: 1 1 auto; min-width: 0; padding: 7px 10px; border-radius: 8px;
+            border: 1px solid var(--border); background: var(--bg); color: var(--fg); font: inherit; font-size: 13px; outline: none;
+        }
+        .issue-form input:focus { border-color: var(--accent); }
+        .issue-form button {
+            padding: 7px 16px; border: 0; border-radius: 8px; cursor: pointer;
+            background: var(--accent); color: #fff; font: inherit; font-size: 13px; font-weight: 700;
+        }
+        .issues-count { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+        .issues-count b { color: var(--fg); font-variant-numeric: tabular-nums; }
+        .issues-empty { border: 1px dashed var(--border); border-radius: 8px; padding: 18px; text-align: center;
+                        color: var(--label); font-size: 12px; }
+        .issues-list { display: flex; flex-direction: column; }
+        .issue-row { padding: 6px 0; border-bottom: 1px solid var(--row-border);
+                     font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; }
+        .issue-row:last-child { border-bottom: 0; }
+
+        /* ---- Live: Delivery table ---- */
+        .delivery-wrap { overflow-x: auto; }
+        table.delivery { width: 100%; border-collapse: collapse; font-size: 12px; }
+        table.delivery th, table.delivery td {
+            text-align: right; padding: 9px 12px; white-space: nowrap;
+            font-variant-numeric: tabular-nums; border-bottom: 1px solid var(--row-border);
+        }
+        table.delivery th { color: var(--label); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; }
+        table.delivery td { color: var(--fg); }
+        table.delivery th.l, table.delivery td.l { text-align: left; }
+        table.delivery td.l { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+        table.delivery th:first-child, table.delivery td:first-child { padding-left: 16px; }
+        table.delivery th:last-child, table.delivery td:last-child { padding-right: 16px; }
+        table.delivery th.n, table.delivery td.n { color: var(--muted); }
+        table.delivery td.warn { color: var(--warn); }
+        table.delivery td.bad  { color: var(--bad); }
+        table.delivery tbody tr:last-child td { border-bottom: 0; }
+
+        /* ---- Live: Agent logs ---- */
+        .logs-card { flex: 1 1 auto; display: flex; flex-direction: column; min-height: 340px; margin-top: 16px; }
+        .logs-head { text-transform: uppercase; }
+        .streaming { margin-left: auto; display: flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 600;
+                     color: var(--ok); text-transform: none; letter-spacing: 0; }
+        .streaming .dot { width: 6px; height: 6px; border-radius: 999px; background: currentColor; }
+        .logs-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 8px 0; }
+        .logbox { display: flex; flex-direction: column; }
+        .logline { display: flex; gap: 12px; padding: 1px 16px;
+                   font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; line-height: 1.7; }
+        .logline:hover { background: var(--card-head); }
+        .log-time { flex: 0 0 auto; color: var(--argnum); font-variant-numeric: tabular-nums; }
+        .log-id { flex: 0 0 auto; color: var(--muted); }
+        .log-msg { min-width: 0; color: var(--fg); white-space: pre-wrap; word-break: break-word; }
+
+        /* ---- Config screen ---- */
+        .cfg-root { display: flex; flex-direction: column; gap: 16px; }
+        .cfg-toolbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .cfg-filter { box-sizing: border-box; width: 280px; max-width: 100%; padding: 7px 10px; border-radius: 8px;
+                      border: 1px solid var(--border); background: var(--card); color: var(--fg); font: inherit; font-size: 13px; outline: none; }
+        .cfg-filter:focus { border-color: var(--accent); }
+        .cfg-toggle { padding: 7px 12px; border-radius: 8px; cursor: pointer; font: inherit; font-size: 12px; font-weight: 600;
+                      color: var(--muted); background: transparent; border: 1px solid var(--border); }
+        .cfg-toggle.active { color: var(--warn); background: color-mix(in srgb, var(--warn) 16%, transparent);
+                             border-color: color-mix(in srgb, var(--warn) 40%, transparent); }
+        .cfg-summary { margin-left: auto; font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums; }
+        .cfg-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+        .cfg-card[hidden] { display: none; }
+        .cfg-card-head { padding: 10px 16px; background: var(--card-head); border-bottom: 1px solid var(--border);
+                         display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .cfg-group-label { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); font-weight: 700; }
+        .cfg-count { font-size: 11px; color: var(--label); font-variant-numeric: tabular-nums; }
+        .cfg-ovr { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--warn);
+                   background: color-mix(in srgb, var(--warn) 16%, transparent);
+                   border: 1px solid color-mix(in srgb, var(--warn) 40%, transparent); padding: 1px 7px; border-radius: 999px; }
+        .cfg-grid { display: flex; flex-direction: column; }
+        .cfg-row { display: grid; grid-template-columns: minmax(220px, 300px) minmax(0, 1fr) minmax(0, 0.8fr);
+                   column-gap: 20px; align-items: baseline; padding: 8px 16px; border-bottom: 1px solid var(--row-border);
+                   font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; }
+        .cfg-row:last-child { border-bottom: 0; }
+        .cfg-row[hidden] { display: none; }
+        .cfg-th { color: var(--label); font-weight: 700; font-size: 11px; text-transform: uppercase; letter-spacing: .05em;
+                  font-family: inherit; }
+        .cfg-var { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+        .cfg-dot { flex: 0 0 auto; width: 5px; height: 5px; border-radius: 999px; background: transparent; }
+        .cfg-dot.on { background: var(--warn); }
+        .cfg-name { color: var(--fg); overflow-wrap: anywhere; }
+        .cfg-value { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+        .cfg-value > span:first-child { overflow-wrap: anywhere; min-width: 0; }
+        .cfg-def { color: var(--argnum); overflow-wrap: anywhere; }
+        .v-num { color: var(--accent); }
+        .v-bool { color: var(--ok); }
+        .v-path { color: var(--muted); }
+        .v-str { color: var(--fg); }
+        .v-secret { color: var(--muted); }
+        .cfg-set { flex: 0 0 auto; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
+                   color: var(--muted); background: var(--track); border: 1px solid var(--chip-border); padding: 0 7px; border-radius: 999px; }
+        .cfg-empty { border: 1px dashed var(--border); border-radius: 10px; padding: 24px; text-align: center;
+                     color: var(--label); font-size: 12px; }
+        .cfg-empty[hidden] { display: none; }
+        @media (max-width: 720px) {
+            .cfg-row { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+            .cfg-row > *:nth-child(3) { grid-column: 1 / -1; padding-top: 2px; }
+        }
+
+        /* ---- Aliases screen ---- */
         .aliases-layout { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 16px; align-items: start; }
         .aliases-list-pane { min-width: 0; }
         @media (max-width: 720px) { .aliases-layout { grid-template-columns: 1fr; } }
@@ -150,10 +254,6 @@
                     background: var(--card-head); flex-wrap: wrap; }
         .cmd-num { width: 20px; height: 20px; flex: 0 0 auto; border-radius: 6px; background: var(--border); color: var(--muted);
                    font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; font-variant-numeric: tabular-nums; }
-        .cmd-label { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--label); font-weight: 700; }
-        .chips { display: flex; flex-wrap: wrap; gap: 4px; }
-        .chip { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 1px 9px; border-radius: 999px;
-                background: var(--track); border: 1px solid var(--chip-border); color: var(--fg); }
         .cmd-body { padding: 12px; display: grid; grid-template-columns: 76px minmax(0, 1fr); gap: 10px 12px; align-items: start; }
         .cmd-body .cmd-label { padding-top: 5px; }
         .code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; color: var(--fg);
@@ -181,30 +281,39 @@
     </nav>
 
     <section id="screen-live" class="screen">
-        <p class="sub">Live status &middot; updates automatically over SSE</p>
-        <div class="grid">
-            <section class="card"><h2>Service</h2>          <div sse-swap="service"><span class="muted">connecting&hellip;</span></div></section>
-            <section class="card"><h2>Connected agents</h2> <div sse-swap="agents"><span class="muted">connecting&hellip;</span></div></section>
-            <section class="card"><h2>Current task</h2>     <div sse-swap="status"><span class="muted">connecting&hellip;</span></div></section>
-            <section class="card">
-                <h2>Issues queue</h2>
+        <div class="statusbar">
+            <span id="sse-indicator" class="sse-ind"><span class="dot"></span><span class="sse-txt">live</span></span>
+            <div class="vitals" sse-swap="service"><span class="muted">connecting&hellip;</span></div>
+        </div>
+
+        <div class="live-top">
+            <section class="card task-card">
+                <div class="task-main" sse-swap="status"><span class="muted">connecting&hellip;</span></div>
+                <div class="task-agents" sse-swap="agents"><span class="muted">connecting&hellip;</span></div>
+            </section>
+            <section class="card issues-card">
+                <div class="card-inline-head"><span class="cmd-label">issues queue</span></div>
                 <form class="issue-form" hx-post="{{BASE}}/issue" hx-target="#issues-list" hx-swap="innerHTML">
                     <input type="number" name="issue_id" min="1" placeholder="issue id" required>
                     <button type="submit">Add</button>
                 </form>
                 <div id="issues-list" sse-swap="issues"><span class="muted">connecting&hellip;</span></div>
             </section>
-            <section class="card"><h2>Delivery queues</h2>  <div sse-swap="queues"><span class="muted">connecting&hellip;</span></div></section>
-            <section class="card"><h2>Send latency</h2>     <div sse-swap="latency"><span class="muted">connecting&hellip;</span></div></section>
         </div>
-        <section class="card logs-card">
-            <h2>Agent logs</h2>
-            <div class="logs-body" sse-swap="logs"><span class="muted">connecting&hellip;</span></div>
+
+        <section class="card flush delivery-card">
+            <div class="card-head">Delivery</div>
+            <div class="delivery-body" sse-swap="delivery"><span class="muted" style="display:block; padding:12px 16px">connecting&hellip;</span></div>
+        </section>
+
+        <section class="card flush logs-card">
+            <div class="card-head logs-head"><span>Agent logs</span><span class="streaming"><span class="dot"></span>streaming</span></div>
+            <div class="logs-body" sse-swap="logs"><span class="muted" style="display:block; padding:12px 16px">connecting&hellip;</span></div>
         </section>
     </section>
 
     <section id="screen-config" class="screen" hidden>
-        <div hx-get="{{BASE}}/config" hx-trigger="load"><span class="muted">loading&hellip;</span></div>
+        <div class="cfg-root" hx-get="{{BASE}}/config" hx-trigger="load"><span class="muted">loading&hellip;</span></div>
     </section>
 
     <section id="screen-aliases" class="screen" hidden>
@@ -241,12 +350,19 @@
 
         (function () {
             var banner = document.getElementById('sse-status');
+            var ind    = document.getElementById('sse-indicator');
             var body   = document.body;
-            function show() { banner.hidden = false; }
-            function hide() { banner.hidden = true; }
-            body.addEventListener('htmx:sseOpen', hide);
-            body.addEventListener('htmx:sseError', show);
-            body.addEventListener('htmx:sseClose', show);
+            function setConnected(connected) {
+                banner.hidden = connected;
+                if (ind) {
+                    ind.classList.toggle('warn', !connected);
+                    var txt = ind.querySelector('.sse-txt');
+                    if (txt) { txt.textContent = connected ? 'live' : 'reconnecting'; }
+                }
+            }
+            body.addEventListener('htmx:sseOpen',  function () { setConnected(true); });
+            body.addEventListener('htmx:sseError', function () { setConnected(false); });
+            body.addEventListener('htmx:sseClose', function () { setConnected(false); });
         })();
 
         (function () {
@@ -254,6 +370,7 @@
             var screens = { live: 'screen-live', config: 'screen-config', aliases: 'screen-aliases' };
             tabs.forEach(function (tab) {
                 tab.addEventListener('click', function () {
+                    if (!tab.getAttribute('data-screen')) { return; }
                     tabs.forEach(function (t) { t.classList.remove('active'); });
                     tab.classList.add('active');
                     var want = tab.getAttribute('data-screen');
@@ -289,6 +406,44 @@
                 if (!btn) { return; }
                 scr.querySelectorAll('.alias-item.active').forEach(function (a) { a.classList.remove('active'); });
                 btn.classList.add('active');
+            });
+        })();
+
+        (function () {
+            var scr = document.getElementById('screen-config');
+            if (!scr) { return; }
+            function apply() {
+                var input  = scr.querySelector('.cfg-filter');
+                var toggle = scr.querySelector('.cfg-toggle');
+                var q      = input ? input.value.trim().toLowerCase() : '';
+                var only   = toggle ? toggle.classList.contains('active') : false;
+                var anyVisible = false;
+                scr.querySelectorAll('.cfg-card').forEach(function (card) {
+                    var shown = 0;
+                    card.querySelectorAll('.cfg-row[data-var]').forEach(function (row) {
+                        var name  = row.getAttribute('data-var') || '';
+                        var val   = row.getAttribute('data-value') || '';
+                        var ovr   = row.getAttribute('data-overridden') === 'true';
+                        var match = (!only || ovr) && (!q || name.indexOf(q) >= 0 || val.indexOf(q) >= 0);
+                        row.hidden = !match;
+                        if (match) { shown++; }
+                    });
+                    var count = card.querySelector('.cfg-count');
+                    if (count) { count.textContent = shown + ' of ' + (count.getAttribute('data-total') || shown); }
+                    card.hidden = (shown === 0);
+                    if (shown > 0) { anyVisible = true; }
+                });
+                var empty = scr.querySelector('.cfg-empty');
+                if (empty) { empty.hidden = anyVisible; }
+            }
+            scr.addEventListener('input', function (e) {
+                if (e.target.classList && e.target.classList.contains('cfg-filter')) { apply(); }
+            });
+            scr.addEventListener('click', function (e) {
+                var t = e.target.closest ? e.target.closest('.cfg-toggle') : null;
+                if (!t) { return; }
+                t.classList.toggle('active');
+                apply();
             });
         })();
     </script>

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -33,7 +33,7 @@ public class DashboardViewTest {
         String html = DashboardView.agents(agents);
         assertTrue(html, html.contains("host-a"));
         assertTrue(html, html.contains("host-b"));
-        assertTrue(html, html.contains(">2<")); // count
+        assertTrue(html, html.contains("2 connected")); // count
     }
 
     @Test
@@ -61,7 +61,7 @@ public class DashboardViewTest {
     }
 
     @Test
-    public void queuesRendersSpoolCounters() throws Exception {
+    public void deliveryRendersCountersAndLatencyColumns() throws Exception {
         PersistentSpool spool = new PersistentSpool(tmp.newFolder("telegram"));
         String first = spool.append("{\"x\":1}");
         spool.append("{\"x\":2}");
@@ -69,71 +69,72 @@ public class DashboardViewTest {
 
         Map<String, PersistentSpool> queues = new LinkedHashMap<>();
         queues.put("telegram", spool);
+        Map<String, LatencyStat> latency = new LinkedHashMap<>();
+        latency.put("telegram", new LatencyStat(16, 126.0, 98.0, 210.0, 244.0, 251.0));
 
-        String html = DashboardView.queues(queues);
+        String html = DashboardView.delivery(queues, latency);
+        assertTrue(html, html.contains("<table class=\"delivery\""));
         assertTrue(html, html.contains("telegram"));
-        assertTrue(html, html.contains("<td class=\"num\">1</td>")); // pending and sent are both 1
+        assertTrue(html, html.contains(">16<"));   // n column
+        assertTrue(html, html.contains("210 ms")); // p95 latency value
+        assertTrue(html, html.contains("<th class=\"l\">queue</th>"));
     }
 
     @Test
-    public void queuesRendersDepthBars() throws Exception {
+    public void deliveryWithoutLatencyShowsDashes() throws Exception {
         PersistentSpool spool = new PersistentSpool(tmp.newFolder("redmine"));
         spool.append("{\"x\":1}");
         Map<String, PersistentSpool> queues = new LinkedHashMap<>();
         queues.put("redmine", spool);
 
-        String html = DashboardView.queues(queues);
-        assertTrue(html, html.contains("barfill"));
-        assertTrue(html, html.contains("style=\"width:"));
+        String html = DashboardView.delivery(queues, new LinkedHashMap<>());
+        assertTrue(html, html.contains("redmine"));
+        assertTrue(html, html.contains("&mdash;")); // no latency yet -> em dashes
     }
 
     @Test
-    public void queuesEmptyShowsPlaceholder() {
-        assertTrue(DashboardView.queues(new LinkedHashMap<>()).contains("no queues"));
-    }
-
-    @Test
-    public void latencyRendersPercentileBars() {
-        Map<String, LatencyStat> stats = new LinkedHashMap<>();
-        stats.put("telegram", new LatencyStat(1043, 45.0, 12.0, 180.0, 240.0, 310.0));
-
-        String html = DashboardView.latency(stats);
-        assertTrue(html, html.contains("telegram"));
-        assertTrue(html, html.contains("p95"));
-        assertTrue(html, html.contains("style=\"width:"));
-        assertTrue(html, html.contains("n=1043"));
-        assertTrue(html, html.contains("180 ms"));
-    }
-
-    @Test
-    public void latencyEmptyShowsNoData() {
-        assertTrue(DashboardView.latency(new LinkedHashMap<>()).contains("no data"));
-    }
-
-    @Test
-    public void barRowClampsFractionAndFormatsWidth() {
-        assertTrue(DashboardView.barRow("p99", "9 ms", 2.0).contains("width:100%"));
-        assertTrue(DashboardView.barRow("p50", "0 ms", -1.0).contains("width:0%"));
+    public void deliveryEmptyShowsPlaceholder() {
+        assertTrue(DashboardView.delivery(new LinkedHashMap<>(), new LinkedHashMap<>()).contains("no queues"));
     }
 
     @Test
     public void statusNullIsIdleWithoutException() {
-        String html = DashboardView.status(null);
+        String html = DashboardView.status(null, "");
         assertTrue(html, html.contains("idle"));
     }
 
     @Test
-    public void statusRendersTaskFields() {
+    public void statusRendersTaskFieldsAndIssueLink() {
         TaskStatus status = TaskStatus.builder()
                 .taskId("task-1")
                 .issueId(42)
                 .taskLine("> deploy web")
                 .taskState(TaskState.taskRunning())
                 .build();
-        String html = DashboardView.status(status);
+        String html = DashboardView.status(status, "https://redmine.example.com/");
         assertTrue(html, html.contains("task-1"));
-        assertTrue(html, html.contains("42"));
         assertTrue(html, html.contains("RUNNING"));
+        assertTrue(html, html.contains("badge"));
+        assertTrue(html, html.contains("href=\"https://redmine.example.com/issues/42\"")); // trailing slash trimmed
+        assertTrue(html, html.contains("#42"));
+    }
+
+    @Test
+    public void statusWithoutRedmineUrlShowsPlainIssue() {
+        TaskStatus status = TaskStatus.builder()
+                .taskId("t").issueId(7).taskState(TaskState.taskRunning()).build();
+        String html = DashboardView.status(status, "");
+        assertFalse(html, html.contains("<a "));
+        assertTrue(html, html.contains("#7"));
+    }
+
+    @Test
+    public void statusRendersErrorMessage() {
+        TaskStatus status = TaskStatus.builder()
+                .taskId("t").issueId(9).taskState(TaskState.taskError("boom <fail>")).build();
+        String html = DashboardView.status(status, "");
+        assertTrue(html, html.contains("task-err"));
+        assertTrue(html, html.contains("boom &lt;fail&gt;")); // escaped
     }
 
     @Test
@@ -157,14 +158,17 @@ public class DashboardViewTest {
     }
 
     @Test
-    public void configRendersNamesGroupsAndMaskedValue() {
+    public void configRendersGroupsMaskedSecretAndSetChip() {
         List<StartupConfigReport.Entry> entries = List.of(
                 new StartupConfigReport.Entry("Redmine", "REDMINE_URL", "http://x", "", false, false),
                 new StartupConfigReport.Entry("Redmine", "TELEGRAM_TOKEN", "•••• (set)", "", true, false));
         String html = DashboardView.config(entries);
-        assertTrue(html, html.contains("Redmine"));
+        assertTrue(html, html.contains("cfg-toolbar"));   // filter toolbar
+        assertTrue(html, html.contains("Redmine"));       // group card header
         assertTrue(html, html.contains("REDMINE_URL"));
-        assertTrue(html, html.contains("•••• (set)"));
+        assertTrue(html, html.contains("••••"));          // secret masked
+        assertTrue(html, html.contains("cfg-set"));       // "set" chip for the secret
+        assertTrue(html, html.contains("v-str"));         // non-secret value colour class
     }
 
     @Test


### PR DESCRIPTION
Reproduces the `design_handoff_live_config` handoffs for the **Live** and **Config** dashboard tabs, keeping the existing stack (htmx + SSE + server-rendered fragments) and routing every color through the existing CSS variables so the light theme keeps working. No new data or metrics — only fields the server already exposes.

## Live
- **Service** card → a header status line (`sse-swap="service"`): SSE live/reconnecting indicator + uptime / heap / agents.
- **Connected agents** → chips inside the **Current task** card (`sse-swap="agents"`): "agents" label + "N connected" pill + one chip per agent (alphabetical).
- **Current task**: state badge, task name (task line), TASK ID, ISSUE rendered as a Redmine link when `REDMINE_URL` is set; the failure error text is kept as a red line.
- **Delivery queues** + **Send latency** are merged into a single **Delivery** table (`delivery` SSE event replaces `queues` + `latency`): queue / pending / dead / sent / dlq / n / mean / p50 / p95 / p99 / max. Depth/percentile bars removed — every number is kept as a column.
- **Agent logs**: full-width, min-height 340px, time + short command id + message per line (id kept), with a streaming indicator.

## Config
- Group cards (Redmine / GitLab / Telegram, Server, Dashboard) with a filter input, an "overridden only" toggle, and a `N variables · M overridden` summary.
- Values colored by type (num / bool / path / str), secrets shown as `••••` + a `set` chip (the secret value is never sent), empty default shown as `—`, overridden rows marked with a dot + a per-group `N overridden` chip. Client-side filter/toggle over the rendered rows; no new server params.

## Notes
- Design elements with no backing data are intentionally omitted (task version, agent-in-task highlight, per-line log type coloring, per-issue status).
- No currently-shown data was removed.

## Tests
- `DashboardViewTest`: replaced the queues/latency/bar tests with `delivery*` tests; updated agents/status/config assertions (status now takes a Redmine base URL; adds issue-link and error-line cases).
- `DashboardHttpTest` / `FullEnvironmentTest`: assert the merged `event: delivery` frame.
- `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS (all modules, both integration tests).