### PR TITLE
fix(telegram): stop sender worker on shutdown to abort retry backoff

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/TelegramClient.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  * ограничением темпа и повтором на 429 по {@code retry_after}. Частые правки одного сообщения коалесятся.
  * Операции персистятся на диск (spool) и переотправляются после рестарта (at-least-once).
  */
-public class TelegramClient {
+public class TelegramClient implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(TelegramClient.class);
 
@@ -40,6 +40,7 @@ public class TelegramClient {
     private final long             minIntervalMs;
     private final PersistentSpool  spool;
     private final LongConsumer     sendLatencyNanos; // nullable: records duration of a successful API call
+    private final Thread           worker;
     private final Gson             gson = new GsonBuilder().disableHtmlEscaping().create();
 
     private final BlockingQueue<Runnable> queue        = new LinkedBlockingQueue<>();
@@ -73,11 +74,21 @@ public class TelegramClient {
         this.spool            = new PersistentSpool(aSpoolDir);
         this.sendLatencyNanos = aSendLatencyNanos;
 
-        Thread worker = new Thread(this::runWorker, "telegram-sender");
+        this.worker = new Thread(this::runWorker, "telegram-sender");
         worker.setDaemon(true);
         worker.start();
 
         replay();
+    }
+
+    /**
+     * Stops the background sender. Interrupting the worker aborts any in-flight retry/backoff so a shutdown
+     * (or test teardown) returns immediately instead of hammering an unreachable endpoint for minutes; the
+     * op being retried is left in the spool for replay on the next start.
+     */
+    @Override
+    public void close() {
+        worker.interrupt();
     }
 
     /** Блокирующая отправка нового сообщения; возвращает message_id. */
@@ -132,6 +143,13 @@ public class TelegramClient {
                 aFuture.complete(id);
             }
         } catch (RuntimeException e) {
+            if (Thread.currentThread().isInterrupted()) {
+                // shutting down mid-retry: keep the op in the spool for replay on the next start
+                if (aFuture != null) {
+                    aFuture.completeExceptionally(e);
+                }
+                return;
+            }
             spool.deadLetter(aFile);
             if (aFuture != null) {
                 aFuture.completeExceptionally(e);
@@ -161,6 +179,9 @@ public class TelegramClient {
             });
             spool.remove(edit.fileName);
         } catch (RuntimeException e) {
+            if (Thread.currentThread().isInterrupted()) {
+                return; // shutting down mid-retry: keep the edit in the spool for replay on the next start
+            }
             spool.deadLetter(edit.fileName);
             LOG.error("telegram edit dead-lettered after {} attempts", Backoff.MAX_ATTEMPTS, e);
         }
@@ -203,6 +224,9 @@ public class TelegramClient {
         RuntimeException last = null;
         for (int attempt = 1; attempt <= Backoff.MAX_ATTEMPTS; attempt++) {
             awaitRateLimit();
+            if (Thread.currentThread().isInterrupted()) {
+                throw new IllegalStateException("Telegram sender stopped", last);
+            }
             try {
                 long start = System.nanoTime();
                 T result = aCall.get();
@@ -211,8 +235,8 @@ public class TelegramClient {
             } catch (RuntimeException e) {
                 last = e;
                 LOG.warn("Telegram call failed (attempt {}/{})", attempt, Backoff.MAX_ATTEMPTS, e);
-                if (attempt < Backoff.MAX_ATTEMPTS) {
-                    sleep(backoffMs(e, attempt));
+                if (attempt < Backoff.MAX_ATTEMPTS && !sleep(backoffMs(e, attempt))) {
+                    throw new IllegalStateException("Telegram sender stopped", e);
                 }
             } finally {
                 lastCallAt = System.currentTimeMillis();
@@ -241,14 +265,17 @@ public class TelegramClient {
         sleep(lastCallAt + minIntervalMs - System.currentTimeMillis());
     }
 
-    private static void sleep(long aMs) {
+    /** Sleeps for {@code aMs}; returns {@code false} if interrupted so a retry loop can abort on shutdown. */
+    private static boolean sleep(long aMs) {
         if (aMs <= 0) {
-            return;
+            return true;
         }
         try {
             Thread.sleep(aMs);
+            return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            return false;
         }
     }
 

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/TelegramClientTest.java
@@ -17,14 +17,17 @@ import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -137,6 +140,42 @@ public class TelegramClientTest {
         verify(service, times(10)).sendMessage(any()); // Backoff.MAX_ATTEMPTS
         assertEquals(0, dir.listFiles((d, n) -> n.endsWith(".json")).length);       // removed from active spool
         assertEquals(1, new File(dir, "dead").listFiles((d, n) -> n.endsWith(".json")).length); // moved to dead-letter
+    }
+
+    @Test
+    public void closeAbortsInFlightRetryPromptly() throws Exception {
+        File dir = tmp.newFolder("close");
+        // a generic failure (not a 429) would otherwise back off exponentially for minutes
+        when(service.sendMessage(any())).thenThrow(new RuntimeException("connection refused"));
+
+        TelegramClient failing = new TelegramClient(service, 0L, dir);
+        AtomicReference<RuntimeException> thrown = new AtomicReference<>();
+        Thread caller = new Thread(() -> {
+            try {
+                failing.sendMessage(1L, "boom", null);
+            } catch (RuntimeException e) {
+                thrown.set(e);
+            }
+        }, "test-caller");
+        caller.start();
+
+        // the worker has failed once and is now in the (long) backoff sleep
+        verify(service, timeout(2000).atLeastOnce()).sendMessage(any());
+
+        long start = System.currentTimeMillis();
+        failing.close();          // interrupts the worker -> aborts the backoff
+        caller.join(3000);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertFalse("sendMessage caller must return after close()", caller.isAlive());
+        assertTrue("close() should abort the retry storm promptly, took " + elapsed + "ms", elapsed < 2000);
+        assertTrue("caller should observe a failure", thrown.get() != null);
+
+        // on shutdown the op is kept for replay, not dead-lettered
+        File[] dead = new File(dir, "dead").listFiles((d, n) -> n.endsWith(".json"));
+        assertTrue("op must not be dead-lettered on shutdown", dead == null || dead.length == 0);
+        assertEquals("op stays in the active spool for replay", 1,
+                dir.listFiles((d, n) -> n.endsWith(".json")).length);
     }
 
     private static TelegramMessage message(long aId) {

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -62,6 +62,7 @@ public class VertxServerApplication {
     private final IServerApplicationListener serverListener;
     private final AgentConnections           agentConnections;
     private final DeployServiceImpl          deployService;
+    private final TelegramClient             telegramClient; // nullable: the test constructor has no Telegram wiring
 
     public static void main(String[] args) {
 
@@ -105,6 +106,7 @@ public class VertxServerApplication {
 
         this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
         this.serverListener = serverListener;
+        this.telegramClient = null;
     }
 
     public VertxServerApplication() {
@@ -160,6 +162,7 @@ public class VertxServerApplication {
 
         this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
         this.serverListener = serverListener;
+        this.telegramClient = telegramClient;
     }
 
     private static List<StartupConfigReport.Entry> buildConfigReport(
@@ -194,6 +197,9 @@ public class VertxServerApplication {
 
     public void stop() {
         LOG.info("Exiting ...");
+        if (telegramClient != null) {
+            telegramClient.close(); // abort any in-flight retry so shutdown does not block on a stuck send
+        }
         vertx.close();
         serverListener.serverStopped();
     }


### PR DESCRIPTION
## Problem
`TelegramClient` retries a failed call up to `Backoff.MAX_ATTEMPTS` (10) with exponential backoff capped at 60s. For a **non-429** failure (e.g. `Connection refused`) the backoff schedule is `1+2+4+8+16+32+60+60+60 ≈ 243s (~4 min)` for a single op, and `sendMessage(...)` blocks the caller on `future.get()` (no timeout) for that whole time.

The worker thread is already a daemon, so it does not keep the JVM alive — but there was **no way to stop it**. On shutdown (or integration-test teardown) a stuck send kept the deploy pipeline thread blocked and delayed `vertx.close()`, which is what turned one transient refused telegram connection on a CI runner into a ~20-minute "Build and test" step.

## Change
- `TelegramClient` now implements `AutoCloseable`. `close()` interrupts the sender worker.
- The retry loop (`callWithRetry`) checks for interruption after the rate-limit wait and treats an interrupted backoff sleep as an abort (`sleep(...)` now returns `false` when interrupted), so a shutdown stops the retries **immediately** instead of finishing the ~4-minute schedule.
- On shutdown the in-flight op is **left in the spool for replay** on the next start (it is not dead-lettered — it was never proven undeliverable).
- `VertxServerApplication.stop()` calls `telegramClient.close()` before `vertx.close()`, so the pipeline thread blocked on a telegram send unblocks and the server shuts down promptly. The integration environment (`LocalEnvironment.close()` → `server.stop()`) benefits automatically.

## Test
- `TelegramClientTest.closeAbortsInFlightRetryPromptly`: with a generic (`Connection refused`-style) failure, a `sendMessage` caller is blocked in the retry storm; `close()` makes it return in well under 2s (vs ~4 min), and the op stays in the active spool (not dead-lettered).
- `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS (all modules).

## Note
Production retry semantics for the normal (non-shutdown) path are unchanged: 10 attempts with the same backoff, then dead-letter.