### PR TITLE
fix(dashboard): accept issue enqueue as GET or POST (proxy rewrite)

### DIFF
--- a/integration-test/src/test/java/io/pne/deploy/tests/DashboardHttpTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/DashboardHttpTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -61,6 +63,16 @@ public class DashboardHttpTest {
             assertEquals(200, added.statusCode());
             assertTrue("issue list should show the added id, got: " + added.body(), added.body().contains("#777"));
 
+            // 3a. the id may also arrive on the query string (GET) — must enqueue, not 405
+            HttpResponse<String> viaQuery = client.send(get("/deploy/dashboard/issue?issue_id=555"), ofString());
+            assertEquals(200, viaQuery.statusCode());
+            assertTrue("query-string id should enqueue, got: " + viaQuery.body(), viaQuery.body().contains("#555"));
+
+            // 3b. a reverse proxy rewrites the htmx POST into a GET keeping the body; that must still enqueue
+            String rewritten = issueViaRawGetWithBody("issue_id=888");
+            assertTrue("proxy-rewritten GET must not be 405, got: " + rewritten, rewritten.startsWith("HTTP/1.1 200"));
+            assertTrue("GET with body should enqueue the id, got: " + rewritten, rewritten.contains("#888"));
+
             // 4. the live SSE stream — first snapshot (all cards) must arrive immediately
             HttpResponse<InputStream> events = client.send(get("/deploy/dashboard/events"), ofInputStream());
             assertEquals(200, events.statusCode());
@@ -76,6 +88,27 @@ public class DashboardHttpTest {
 
     private static HttpRequest get(String path) {
         return HttpRequest.newBuilder(URI.create(BASE + path)).GET().build();
+    }
+
+    /**
+     * Sends a raw {@code GET} carrying a url-encoded body — exactly what the production reverse proxy does
+     * when it rewrites the htmx POST — and returns the full HTTP response. Java's {@link HttpClient} forbids
+     * a body on GET, hence the raw socket.
+     */
+    private static String issueViaRawGetWithBody(String aBody) throws Exception {
+        byte[] payload = aBody.getBytes(UTF_8);
+        String head = "GET /deploy/dashboard/issue HTTP/1.1\r\n"
+                + "Host: 127.0.0.1:" + PORT + "\r\n"
+                + "Content-Type: application/x-www-form-urlencoded\r\n"
+                + "Content-Length: " + payload.length + "\r\n"
+                + "Connection: close\r\n\r\n";
+        try (Socket socket = new Socket("127.0.0.1", PORT)) {
+            OutputStream out = socket.getOutputStream();
+            out.write(head.getBytes(UTF_8));
+            out.write(payload);
+            out.flush();
+            return new String(socket.getInputStream().readAllBytes(), UTF_8);
+        }
     }
 
     private static IVertxServerConfiguration config() {

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -11,7 +11,6 @@ import io.pne.deploy.server.vertx.status.model.TaskStatus;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import org.slf4j.Logger;
@@ -22,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
+import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -205,15 +205,17 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         return "";
     }
 
-    /** POST {base}/issue with form field issue_id -> enqueue, then return the refreshed issues fragment. */
+    /**
+     * {base}/issue with {@code issue_id} in the query string or the url-encoded body -> enqueue, then return
+     * the refreshed issues fragment. Method-agnostic on purpose: the reverse proxy in front of the dashboard
+     * rewrites the htmx POST into a GET (keeping the body), so requiring POST would 405 every "Add".
+     */
     private void handleIssue(HttpServerRequest aRequest) {
-        if (aRequest.method() != HttpMethod.POST) {
-            aRequest.response().setStatusCode(405).end("Method not allowed\n");
-            return;
-        }
-        aRequest.setExpectMultipart(true);
-        aRequest.endHandler(aVoid -> {
-            String raw   = aRequest.getFormAttribute("issue_id");
+        aRequest.bodyHandler(aBody -> {
+            String raw = aRequest.getParam("issue_id"); // query string, if any
+            if (raw == null || raw.isBlank()) {
+                raw = formField(aBody.toString(UTF_8), "issue_id"); // url-encoded body
+            }
             String error = null;
             try {
                 long id = Long.parseLong(raw == null ? "" : raw.trim());
@@ -229,8 +231,26 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             }
             String body = (error == null ? "" : "<p class=\"pill bad\">" + DashboardView.esc(error) + "</p>")
                     + DashboardView.issues(new ArrayList<>(pendingIssues));
-            aRequest.response().putHeader("Content-Type", "text/html; charset=utf-8").end(body);
+            aRequest.response()
+                    .putHeader("Content-Type", "text/html; charset=utf-8")
+                    .putHeader("Cache-Control", "no-store")
+                    .end(body);
         });
+    }
+
+    /** First value of {@code aName} in an application/x-www-form-urlencoded body, URL-decoded; null if absent. */
+    private static String formField(String aBody, String aName) {
+        if (aBody == null || aBody.isEmpty()) {
+            return null;
+        }
+        for (String pair : aBody.split("&")) {
+            int eq = pair.indexOf('=');
+            String key = URLDecoder.decode(eq >= 0 ? pair.substring(0, eq) : pair, UTF_8);
+            if (aName.equals(key)) {
+                return eq >= 0 ? URLDecoder.decode(pair.substring(eq + 1), UTF_8) : "";
+            }
+        }
+        return null;
     }
 
     private void handleEvents(HttpServerRequest aRequest) {


### PR DESCRIPTION
## Problem
Clicking **Add** on the dashboard Issues card returns **405 Method Not Allowed**, so issues can't be enqueued.

The browser sends `POST /deploy/dashboard/issue` (htmx `hx-post`, body `issue_id=…`), but the reverse proxy in front of the deploy server **rewrites the request to `GET`** while keeping the url-encoded body (backend capture: `GET /deploy/dashboard/issue`, `Content-Length: 15`, body `issue_id=168059`, `Connection: upgrade`, `X-Real-IP`/`X-Forwarded-For` → nginx). `handleIssue` required POST and 405'd the rewritten GET.

## Change
`DashboardHttpHandler.handleIssue` is now **method-agnostic**: it reads `issue_id` from the query string, and falls back to parsing the url-encoded request body — so it works whether the request arrives as POST or as the proxy's GET-with-body. The response also sets `Cache-Control: no-store`. Enqueue/validation and the returned issues fragment are unchanged. No client change (`hx-post` stays).

The dashboard has no app-level auth (auth is at the proxy) and this endpoint already had no CSRF token, so accepting the id via GET does not change the threat model.

## Tests (`DashboardHttpTest`)
- Existing `POST issue_id=777` → 200, `#777` (now exercises the body-parse path).
- New: `GET …/issue?issue_id=555` → 200, `#555` (query-string path).
- New: a **raw socket `GET` carrying a url-encoded body** (`issue_id=888`) — reproduces the proxy exactly — must return `200` (not `405`) and contain `#888`. (Java `HttpClient` forbids GET bodies, hence the raw socket.)
- `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS.

## Note
The real root cause is nginx converting `POST`→`GET` for `/deploy/…` (unusual — it keeps the body). This app-side change unblocks the dashboard; you may still want to fix the proxy (look for a `rewrite`/redirect or `proxy_method` on that location) so POST is passed through cleanly.