### PR TITLE
fix(redmine): diff by gitlab= token, drop sandbox skip, add logging

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
@@ -53,9 +53,14 @@ public class DiffServiceImpl implements DiffService {
     }
 
     public void processDiff(List<DiffTask> tasks, int issueId) {
-        if (tasks == null || tasks.isEmpty()) return;
+        if (tasks == null || tasks.isEmpty()) {
+            LOG.info("Diff: nothing to send for issue {} (no diff tasks)", issueId);
+            return;
+        }
 
         Map<DiffKey, DiffTask> aggregated = aggregate(tasks);
+        LOG.info("Diff: processing {} diff task(s) ({} after aggregation) for issue {}",
+                tasks.size(), aggregated.size(), issueId);
         Map<Integer, String> subjectCache = new HashMap<>();
 
         StringBuilder fullRedmineMessage = new StringBuilder();
@@ -63,12 +68,17 @@ public class DiffServiceImpl implements DiffService {
 
         for (DiffTask diffTask : aggregated.values()) {
             List<String> diffs = gitlab.getTagDiff(diffTask);
+            LOG.info("Diff: {} commit(s) for {} ({} -> {}), gitlab project {}",
+                    diffs == null ? 0 : diffs.size(), diffTask.getIdsString(),
+                    diffTask.getOldVersion(), diffTask.getNewVersion(), diffTask.getGitlabProject());
             List<DiffLink> diffLinks = mapDiffIssues(diffs, subjectCache);
 
             fullRedmineMessage.append(constructRedmineMessage(diffTask, diffLinks)).append("\n");
             fullTelegramMessage.addAll(constructTelegramMessage(diffTask, diffLinks));
         }
 
+        LOG.info("Diff: sending Redmine comment ({} chars) and {} Telegram message(s) for issue {}",
+                fullRedmineMessage.length(), fullTelegramMessage.size(), issueId);
         redmine.enqueueAddComment(issueId, fullRedmineMessage.toString());
         telegram.sendMessages(fullTelegramMessage);
     }
@@ -76,49 +86,50 @@ public class DiffServiceImpl implements DiffService {
     public List<DiffTask> getCurrentVersion(Task task) {
         List<DiffTask> diffTasks = new ArrayList<>();
         if (task == null || task.commands.isEmpty()) {
+            LOG.info("Diff: no task/commands, nothing to diff");
             return diffTasks;
         }
+        // A command is diff-eligible purely by its arguments: a version, an old-version url, and a gitlab=<id>.
+        LOG.info("Diff: scanning {} command(s) of '{}' (need version + url + gitlab=<id>)",
+                task.commands.size(), task.taskLine);
         for (TaskCommand command : task.commands) {
             if (command == null) {
                 continue;
             }
-            if (command.command.name.contains("sandbox")) {
-                continue;
-            }
+            String name = command.command.name;
             try {
                 String newVersion = parseStringFromArguments(command.command.arguments, VERSION_LIKE);
                 if (newVersion == null) {
-                    LOG.debug("Skip command (no new version): {}", command);
+                    LOG.info("Diff: skip '{}' — no version argument", name);
                     continue;
                 }
                 String linkForOldVersion = parseStringFromArguments(command.command.arguments, LINK_LIKE);
                 if (linkForOldVersion == null) {
-                    LOG.debug("Skip command (no old version link): {}", command);
+                    LOG.info("Diff: skip '{}' — no old-version url argument", name);
                     continue;
                 }
                 Integer gitlabProject = parseGitlabProjectFromArguments(command.command.arguments);
                 if (gitlabProject == null) {
-                    LOG.debug("Skip command (no gitlab project id): {}", command);
+                    LOG.info("Diff: skip '{}' — no gitlab=<id> argument", name);
                     continue;
                 }
                 String oldVersion = getUrlContent(linkForOldVersion);
-                if (oldVersion == null) {
-                    LOG.debug("Skip command (old version is null): {}", command);
+                if (oldVersion == null || oldVersion.isEmpty()) {
+                    LOG.info("Diff: skip '{}' — old version is empty from {}", name, linkForOldVersion);
                     continue;
                 }
-                if (oldVersion.isEmpty()) {
-                    LOG.debug("Skip command (old version is empty): {}", command);
-                    continue;
-                }
+                LOG.info("Diff: include '{}' — gitlab={}, {} -> {}, agents={}",
+                        name, gitlabProject, oldVersion, newVersion, Arrays.toString(command.agents.getIds()));
                 diffTasks.add(new DiffTask(command.agents.getIds(),
                         gitlabProject,
                         task.taskLine,
                         oldVersion,
                         newVersion));
             } catch (Exception e) {
-                LOG.error("Can't get data for command: {}", command.toString(), e);
+                LOG.error("Diff: can't build diff task for command '{}'", name, e);
             }
         }
+        LOG.info("Diff: {} diff task(s) built for '{}'", diffTasks.size(), task.taskLine);
         return diffTasks;
     }
 

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
@@ -100,6 +100,7 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
         Task task = parseTask(aIssue.issueId(), aIssue.description());
         List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
         int issueId = aIssue.issueId();
+        LOG.info("Diff: submitting {} diff task(s) for issue {} to background processing", diffTasks.size(), issueId);
         diffExecutor.submit(() -> {
             try {
                 diffService.processDiff(diffTasks, issueId);

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteGitlabServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteGitlabServiceImpl.java
@@ -58,6 +58,7 @@ public class RemoteGitlabServiceImpl implements IRemoteGitlabService {
 
     private GitlabDiffData fetchGitlabDiffData(DiffTask diffTask) {
         String requestUrl = gitlabUrl + API_1 + diffTask.getGitlabProject() + API_2 + FROM + getTagFromVersion(diffTask.getOldVersion()) + TO + getTagFromVersion(diffTask.getNewVersion());
+        LOG.info("Gitlab compare: GET {}", requestUrl); // the api key is in the Authorization header, not the url
 
         HttpRequest request = HttpRequest.builder()
                 .url(requestUrl)
@@ -72,9 +73,14 @@ public class RemoteGitlabServiceImpl implements IRemoteGitlabService {
         }
         String responseBody = new String(response.getBody(), UTF_8);
         if (response.getStatusCode() != 200) {
+            LOG.warn("Gitlab compare failed: HTTP {} for project {} ({} -> {})", response.getStatusCode(),
+                    diffTask.getGitlabProject(), diffTask.getOldVersion(), diffTask.getNewVersion());
             throw new IllegalStateException("Can't get diff for tags " + diffTask.getOldVersion() + " and " + diffTask.getNewVersion() + " for project " + diffTask.getGitlabProject());
         }
-        return gson.fromJson(responseBody, GitlabDiffData.class);
+        GitlabDiffData data = gson.fromJson(responseBody, GitlabDiffData.class);
+        LOG.info("Gitlab compare: HTTP 200, {} commit(s) for project {}",
+                data == null || data.getCommits() == null ? 0 : data.getCommits().size(), diffTask.getGitlabProject());
+        return data;
     }
 
     private String getTagFromVersion(String version) {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
@@ -5,14 +5,27 @@ import io.pne.deploy.client.redmine.remote.IRemoteGitlabService;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
+import io.pne.deploy.agent.api.command.AgentCommand;
+import io.pne.deploy.agent.api.command.AgentCommandParameters;
+import io.pne.deploy.agent.api.command.AgentCommandType;
+import io.pne.deploy.server.api.task.AgentFinder;
+import io.pne.deploy.server.api.task.Task;
+import io.pne.deploy.server.api.task.TaskCommand;
+import io.pne.deploy.server.api.task.TaskId;
+import io.pne.deploy.server.api.task.TaskParameters;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,5 +76,49 @@ public class DiffServiceProcessDiffTest {
     public void processDiffWithNoTasksTouchesNoCollaborators() {
         diffService.processDiff(Collections.emptyList(), 1);
         verifyNoInteractions(gitlab, telegram, redmine);
+    }
+
+    /**
+     * Diff-eligibility is decided purely by the arguments (version + old-version url + gitlab=&lt;id&gt;), not by
+     * the script name: a "sandbox" command with a gitlab token is now included, and one without a token is not.
+     */
+    @Test
+    public void getCurrentVersionSelectsByGitlabTokenNotName() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/version", exchange -> {
+            byte[] body = "3.36.16-42\n".getBytes(UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        String oldVersionUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/version";
+        try {
+            // name contains "sandbox" but has version + url + gitlab=114 -> must be INCLUDED
+            TaskCommand ui = new TaskCommand(
+                    new AgentFinder(new String[]{"dui-1"}),
+                    new AgentCommand(new AgentCommandParameters(), AgentCommandType.SHELL,
+                            "./bin/redeploy-sandbox-ui.sh",
+                            Arrays.asList("3.36.16-100", oldVersionUrl, "gitlab=114")));
+            // no url, no gitlab token -> must be EXCLUDED
+            TaskCommand skin = new TaskCommand(
+                    new AgentFinder(new String[]{"dpub-2"}),
+                    new AgentCommand(new AgentCommandParameters(), AgentCommandType.SHELL,
+                            "./bin/redeploy-sandbox-skin.sh",
+                            singletonList("3.36.16-100")));
+            Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                    Arrays.asList(ui, skin), "msk-sandbox-ui 3.36.16-100", 168059);
+
+            List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
+
+            assertEquals("only the command carrying gitlab=<id> is eligible", 1, diffTasks.size());
+            DiffTask built = diffTasks.get(0);
+            assertEquals(Integer.valueOf(114), built.getGitlabProject());
+            assertEquals("3.36.16-42", built.getOldVersion());
+            assertEquals("3.36.16-100", built.getNewVersion());
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
## Problem
Deploy notifications (GitLab diff → Redmine comment + Telegram) were never sent for `msk-sandbox-*` aliases. `DiffServiceImpl.getCurrentVersion` skipped every command whose script name contained `"sandbox"`, so `redeploy-sandbox-ui.sh` / `redeploy-sandbox-skin.sh` were dropped, the diff-task list came back empty, and `processDiff` returned early — silently. Two production logs (a same-version re-deploy and a real `3.36.16-42 → 3.36.16-100` upgrade) confirmed the skip was the sole cause; the whole diff path logged nothing at INFO, so it was invisible.

## Change
- **Drop the `name.contains("sandbox")` skip.** A command is diff-eligible purely by its arguments: a version, an old-version URL, and a `gitlab=<id>` token. The `gitlab=` token is the decisive signal, so diff is opt-in per command via the alias (no dependency on how the `.sh` is named).
- **Add INFO logging across the diff pipeline** so it's visible what happens:
  - `getCurrentVersion`: how many commands are scanned, and for each command whether it is included or skipped and why (no version / no url / no `gitlab=<id>` / empty old version), plus the built `old → new`.
  - `processDiff`: number of diff tasks (before/after aggregation), commits per task, and the final "sending Redmine comment + N Telegram messages" line (or "nothing to send" when empty).
  - `RemoteGitlabServiceImpl`: the compare request URL (the API key stays in the `Authorization` header, not logged), a warning with the HTTP status on non-200, and the returned commit count.
  - `RedmineIssuesProcessServiceImpl`: logs the diff-task count submitted to the background `redmine-diff` executor.

## Test
- `DiffServiceProcessDiffTest.getCurrentVersionSelectsByGitlabTokenNotName`: a `sandbox`-named command with `version + url + gitlab=114` (old version served by a local `HttpServer`) is now **included** (1 diff task, project 114, `3.36.16-42 → 3.36.16-100`); a command without a `gitlab=` token is **excluded**.
- Existing `processDiff` tests unchanged. `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS.