### PR TITLE
feat(dashboard): server log page, agent-tagged logs, gitlab compare fix

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteGitlabServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteGitlabServiceImpl.java
@@ -21,7 +21,7 @@ public class RemoteGitlabServiceImpl implements IRemoteGitlabService {
     private static final Logger LOG = LoggerFactory.getLogger(RemoteGitlabServiceImpl.class);
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String AUTHORIZATION_HEADER_PART = "Bearer ";
-    private static final String API_1 = "/git/api/v4/projects/";
+    private static final String API_1 = "/api/v4/projects/"; // GITLAB_URL already carries the custom /git prefix
     private static final String API_2 = "/repository/compare?";
     private static final String FROM = "from=";
     private static final String TO = "&to=";
@@ -33,9 +33,14 @@ public class RemoteGitlabServiceImpl implements IRemoteGitlabService {
     private final HttpRequestParameters requestParameters = HttpRequestParameters.builder().timeouts(new HttpTimeouts(20_000, 20_000)).build();
 
     public RemoteGitlabServiceImpl(IRedmineRemoteConfig aConfig) {
-        gitlabUrl = aConfig.gitlabUrl();
-        gitlabApiKey = aConfig.gitlabApiKey();
-        client = new HttpClientImpl();
+        this(aConfig.gitlabUrl(), aConfig.gitlabApiKey(), new HttpClientImpl());
+    }
+
+    /** Injectable constructor for tests (mock the HTTP client). */
+    RemoteGitlabServiceImpl(String aGitlabUrl, String aGitlabApiKey, IHttpClient aClient) {
+        gitlabUrl = aGitlabUrl;
+        gitlabApiKey = aGitlabApiKey;
+        client = aClient;
         gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
     }
 
@@ -57,7 +62,7 @@ public class RemoteGitlabServiceImpl implements IRemoteGitlabService {
     }
 
     private GitlabDiffData fetchGitlabDiffData(DiffTask diffTask) {
-        String requestUrl = gitlabUrl + API_1 + diffTask.getGitlabProject() + API_2 + FROM + getTagFromVersion(diffTask.getOldVersion()) + TO + getTagFromVersion(diffTask.getNewVersion());
+        String requestUrl = compareUrl(diffTask);
         LOG.info("Gitlab compare: GET {}", requestUrl); // the api key is in the Authorization header, not the url
 
         HttpRequest request = HttpRequest.builder()
@@ -71,16 +76,39 @@ public class RemoteGitlabServiceImpl implements IRemoteGitlabService {
         } catch (Exception e) {
             throw new IllegalStateException("Can't send request to " + requestUrl, e);
         }
-        String responseBody = new String(response.getBody(), UTF_8);
-        if (response.getStatusCode() != 200) {
-            LOG.warn("Gitlab compare failed: HTTP {} for project {} ({} -> {})", response.getStatusCode(),
-                    diffTask.getGitlabProject(), diffTask.getOldVersion(), diffTask.getNewVersion());
-            throw new IllegalStateException("Can't get diff for tags " + diffTask.getOldVersion() + " and " + diffTask.getNewVersion() + " for project " + diffTask.getGitlabProject());
+        int    status = response.getStatusCode();
+        String body   = new String(response.getBody(), UTF_8);
+        if (status != 200) {
+            LOG.warn("Gitlab compare: HTTP {} for {} — body: {}", status, requestUrl, snippet(body));
+            throw new IllegalStateException("Gitlab compare HTTP " + status + " for project " + diffTask.getGitlabProject()
+                    + " (" + diffTask.getOldVersion() + " -> " + diffTask.getNewVersion() + "): " + snippet(body));
         }
-        GitlabDiffData data = gson.fromJson(responseBody, GitlabDiffData.class);
-        LOG.info("Gitlab compare: HTTP 200, {} commit(s) for project {}",
-                data == null || data.getCommits() == null ? 0 : data.getCommits().size(), diffTask.getGitlabProject());
-        return data;
+        try {
+            GitlabDiffData data = gson.fromJson(body, GitlabDiffData.class);
+            LOG.info("Gitlab compare: HTTP {}, {} commit(s) for project {}",
+                    status, data == null || data.getCommits() == null ? 0 : data.getCommits().size(), diffTask.getGitlabProject());
+            return data;
+        } catch (RuntimeException e) {
+            LOG.warn("Gitlab compare: HTTP {} but body is not valid JSON for {} — body: {}", status, requestUrl, snippet(body));
+            throw new IllegalStateException("Gitlab compare unparseable body (HTTP " + status + ") for project "
+                    + diffTask.getGitlabProject() + ": " + snippet(body), e);
+        }
+    }
+
+    /** GitLab "compare two tags" API url. {@code GITLAB_URL} already carries the custom prefix, so API_1 must not. */
+    String compareUrl(DiffTask diffTask) {
+        return gitlabUrl + API_1 + diffTask.getGitlabProject() + API_2
+                + FROM + getTagFromVersion(diffTask.getOldVersion())
+                + TO + getTagFromVersion(diffTask.getNewVersion());
+    }
+
+    /** First ~500 chars of the response body, stripped, for error logs; never includes request headers. */
+    private static String snippet(String body) {
+        if (body == null) {
+            return "";
+        }
+        String trimmed = body.strip();
+        return trimmed.length() > 500 ? trimmed.substring(0, 500) + "…(" + trimmed.length() + " chars)" : trimmed;
     }
 
     private String getTagFromVersion(String version) {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/RemoteGitlabServiceImplTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/RemoteGitlabServiceImplTest.java
@@ -1,18 +1,71 @@
 package io.pne.deploy.client.redmine.remote.impl;
 
+import com.payneteasy.http.client.api.HttpResponse;
+import com.payneteasy.http.client.api.IHttpClient;
 import com.payneteasy.startup.parameters.StartupParametersFactory;
 import io.pne.deploy.client.redmine.process.data_model.DiffTask;
 import io.pne.deploy.client.redmine.remote.IRemoteGitlabService;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Collections;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class RemoteGitlabServiceImplTest {
-    @Ignore
+
+    private static final String GITLAB_URL = "https://code.clubber.me/git"; // includes the custom /git prefix
+
+    @Ignore // manual: hits real GitLab
     @Test
     public void getDiffTest() {
         IRedmineRemoteConfig config = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
         IRemoteGitlabService gitlabService = new RemoteGitlabServiceImpl(config);
-        DiffTask diffTask = new DiffTask(new String[0], 1, "test", "1","2");
+        DiffTask diffTask = new DiffTask(new String[0], 1, "test", "1", "2");
         System.out.println(String.join("\\=,\\=", gitlabService.getTagDiff(diffTask)));
+    }
+
+    @Test
+    public void compareUrlHasSingleGitPrefix() {
+        RemoteGitlabServiceImpl svc = new RemoteGitlabServiceImpl(GITLAB_URL, "key", mock(IHttpClient.class));
+        String url = svc.compareUrl(new DiffTask(new String[0], 114, "t", "1", "2"));
+        assertEquals("https://code.clubber.me/git/api/v4/projects/114/repository/compare?from=paynet-1-jdk21&to=paynet-2-jdk21", url);
+    }
+
+    @Test
+    public void nonOkResponseThrowsWithStatusAndBody() throws Exception {
+        IHttpClient client = mock(IHttpClient.class);
+        when(client.send(any(), any())).thenReturn(response(404, "{\"error\":\"404 Not Found\"}"));
+        RemoteGitlabServiceImpl svc = new RemoteGitlabServiceImpl(GITLAB_URL, "key", client);
+        try {
+            svc.getTagDiff(new DiffTask(new String[0], 114, "t", "1", "2"));
+            fail("expected failure on non-200");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("404"));
+            assertTrue(e.getMessage(), e.getMessage().contains("Not Found"));
+        }
+    }
+
+    @Test
+    public void unparseableOkBodyThrowsWithBody() throws Exception {
+        IHttpClient client = mock(IHttpClient.class);
+        when(client.send(any(), any())).thenReturn(response(200, "\"oops\"")); // 200 but not the expected object
+        RemoteGitlabServiceImpl svc = new RemoteGitlabServiceImpl(GITLAB_URL, "key", client);
+        try {
+            svc.getTagDiff(new DiffTask(new String[0], 114, "t", "1", "2"));
+            fail("expected failure on unparseable body");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("oops"));
+        }
+    }
+
+    private static HttpResponse response(int status, String body) {
+        return new HttpResponse(status, "", Collections.emptyList(), body.getBytes(UTF_8));
     }
 }

--- a/integration-test/src/test/java/io/pne/deploy/tests/TestServerApplicationListener.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/TestServerApplicationListener.java
@@ -63,8 +63,8 @@ public class TestServerApplicationListener implements IServerApplicationListener
     }
 
     @Override
-    public <T extends IAgentClientMessage> void didReceiveMessage(T aMessage) {
-        LOG.debug("didReceiveMessage: {}", aMessage);
+    public <T extends IAgentClientMessage> void didReceiveMessage(String aAgentId, T aMessage) {
+        LOG.debug("didReceiveMessage from {}: {}", aAgentId, aMessage);
         received.add(aMessage);
     }
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/AgentConnections.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/AgentConnections.java
@@ -30,7 +30,7 @@ public class AgentConnections {
         LOG.info("Agent disconnected: {}", agentId);
     }
 
-    private String getAgentId(ServerWebSocket aSocket) {
+    public String getAgentId(ServerWebSocket aSocket) {
         PathParameters pathParameters = new PathParameters(aSocket.path());
         return pathParameters.getLast();
     }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerApplicationListenerNoOp.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerApplicationListenerNoOp.java
@@ -19,8 +19,8 @@ public class ServerApplicationListenerNoOp implements IServerApplicationListener
     }
 
     @Override
-    public <T extends IAgentClientMessage> void didReceiveMessage(T aMessage) {
-        LOG.info("Received message: {}", aMessage);
+    public <T extends IAgentClientMessage> void didReceiveMessage(String aAgentId, T aMessage) {
+        LOG.info("Received message from {}: {}", aAgentId, aMessage);
     }
 
     @Override

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerWebSocketFrameHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerWebSocketFrameHandler.java
@@ -7,7 +7,6 @@ import io.pne.deploy.agent.api.messages.RunAgentCommandLog;
 import io.pne.deploy.agent.api.messages.RunAgentCommandResponse;
 import io.pne.deploy.server.IServerApplicationListener;
 import io.pne.deploy.server.api.ITaskExecutionListener;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.WebSocketFrame;
 import org.slf4j.Logger;
@@ -15,7 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 
-public class ServerWebSocketFrameHandler implements Handler<WebSocketFrame> {
+public class ServerWebSocketFrameHandler {
 
 
     private static final Logger LOG = LoggerFactory.getLogger(ServerWebSocketFrameHandler.class);
@@ -34,8 +33,7 @@ public class ServerWebSocketFrameHandler implements Handler<WebSocketFrame> {
         listener = aListener;
     }
 
-    @Override
-    public void handle(WebSocketFrame aEvent) {
+    public void onFrame(String aAgentId, WebSocketFrame aEvent) {
         if (!aEvent.isBinary()) {
             LOG.warn("Frame is not binary {}", aEvent);
             return;
@@ -49,7 +47,7 @@ public class ServerWebSocketFrameHandler implements Handler<WebSocketFrame> {
         AgentMessageType    type    = AgentMessageType.findType(typeId);
         IAgentClientMessage message = parseMessage(type, buffer);
 
-        serverListener.didReceiveMessage(message);
+        serverListener.didReceiveMessage(aAgentId, message);
         LOG.debug("Got {}", message);
 
         switch (type) {
@@ -61,7 +59,7 @@ public class ServerWebSocketFrameHandler implements Handler<WebSocketFrame> {
 
             case RUN_COMMAND_LOG:
                 RunAgentCommandLog logMessage = (RunAgentCommandLog) message;
-                LOG_AGENT.info("{}: {}", logMessage.commandId, logMessage.message);
+                LOG_AGENT.info("{} {}: {}", aAgentId, logMessage.commandId, logMessage.message);
                 listener.onCommandLog(logMessage);
                 break;
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -102,7 +102,7 @@ public class VertxServerApplication {
                 this.vertx, agentConnections, pendingIssues, new LinkedHashMap<>(), statusHttpHandler::getLatestTaskStatus,
                 null, new AgentLogBuffer(200),
                 buildConfigReport(redmineConfig, aConfig, dashboardConfig), aConfig.getAliasesDir(),
-                dashboardConfig.path(), dashboardConfig.refreshMs());
+                dashboardConfig.path(), dashboardConfig.refreshMs(), "");
 
         this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
         this.serverListener = serverListener;
@@ -158,7 +158,7 @@ public class VertxServerApplication {
                 this.vertx, agentConnections, pendingIssues, dashboardQueues, statusHttpHandler::getLatestTaskStatus,
                 metrics, agentLogBuffer,
                 buildConfigReport(redmineConfig, config, dashboardConfig), config.getAliasesDir(),
-                dashboardConfig.path(), dashboardConfig.refreshMs());
+                dashboardConfig.path(), dashboardConfig.refreshMs(), dashboardConfig.serverLogFile());
 
         this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
         this.serverListener = serverListener;

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplicationListener.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplicationListener.java
@@ -72,10 +72,10 @@ public class VertxServerApplicationListener implements IServerApplicationListene
     }
 
     @Override
-    public <T extends IAgentClientMessage> void didReceiveMessage(T aMessage) {
+    public <T extends IAgentClientMessage> void didReceiveMessage(String aAgentId, T aMessage) {
         // Capture agent command output for the dashboard; connect/disconnect are socket events, not messages.
         if (agentLogBuffer != null && aMessage instanceof RunAgentCommandLog log) {
-            agentLogBuffer.add(log.commandId, log.message);
+            agentLogBuffer.add(aAgentId, log.commandId, log.message);
         }
     }
 

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
@@ -73,7 +73,8 @@ public class WebSocketVerticle extends AbstractVerticle {
 
                     connections.addAgent(aSocket);
 
-                    aSocket.frameHandler(serverWebSocketFrameHandler);
+                    String agentId = connections.getAgentId(aSocket);
+                    aSocket.frameHandler(frame -> serverWebSocketFrameHandler.onFrame(agentId, frame));
 
                     aSocket.closeHandler(aVoid -> {
                         connections.removeAgent(aSocket);

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/AgentLogBuffer.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/AgentLogBuffer.java
@@ -19,8 +19,8 @@ public class AgentLogBuffer {
         this.capacity = Math.max(1, aCapacity);
     }
 
-    public synchronized void add(String aCommandId, String aMessage) {
-        lines.addLast(new LogLine(System.currentTimeMillis(), aCommandId, aMessage));
+    public synchronized void add(String aAgentId, String aCommandId, String aMessage) {
+        lines.addLast(new LogLine(System.currentTimeMillis(), aAgentId, aCommandId, aMessage));
         while (lines.size() > capacity) {
             lines.removeFirst();
         }
@@ -36,7 +36,7 @@ public class AgentLogBuffer {
         return out;
     }
 
-    /** One captured log line. {@code commandId} correlates lines of one command; there is no agent id. */
-    public record LogLine(long epochMs, String commandId, String message) {
+    /** One captured log line. {@code agentId} is the source agent; {@code commandId} correlates lines of one command. */
+    public record LogLine(long epochMs, String agentId, String commandId, String message) {
     }
 }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -61,6 +61,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final File                         aliasesDir;
     private final long                         refreshMs;
     private final String                       redmineBaseUrl; // for linking issue ids on the task card
+    private final String                       serverLogFile;  // tailed by the Log screen; blank disables it
 
     private final String basePath;
     private final String eventsPath;
@@ -70,6 +71,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final String configPath;
     private final String aliasesPath;
     private final String aliasPath;
+    private final String logEventsPath;
 
     private final Buffer indexHtml;
     private final Buffer htmxJs = readResource("/dashboard/htmx.min.js");
@@ -87,6 +89,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             , File aAliasesDir
             , String aBasePath
             , long aRefreshMs
+            , String aServerLogFile
     ) {
         this.vertx              = aVertx;
         this.agents             = aAgents;
@@ -99,6 +102,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.aliasesDir         = aAliasesDir;
         this.refreshMs          = aRefreshMs;
         this.redmineBaseUrl     = findConfig(aConfigEntries, "REDMINE_URL");
+        this.serverLogFile      = aServerLogFile;
 
         this.basePath    = normalize(aBasePath);
         this.eventsPath  = basePath + "/events";
@@ -108,6 +112,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.configPath  = basePath + "/config";
         this.aliasesPath = basePath + "/aliases";
         this.aliasPath   = basePath + "/alias";
+        this.logEventsPath = basePath + "/log/events";
 
         this.indexHtml = Buffer.buffer(readResourceString("/dashboard/index.html").replace("{{BASE}}", basePath));
     }
@@ -134,6 +139,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             handleAliasList(aRequest);
         } else if (aliasPath.equals(path)) {
             handleAliasDetail(aRequest, aRequest.getParam("name"));
+        } else if (logEventsPath.equals(path)) {
+            handleLogEvents(aRequest);
         } else if (basePath.equals(path) || (basePath + "/").equals(path)) {
             serve(aRequest, "text/html; charset=utf-8", indexHtml);
         } else {
@@ -271,6 +278,61 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         });
 
         aRequest.connection().closeHandler(aVoid -> vertx.cancelTimer(timerId));
+    }
+
+    /** SSE tail of the configured server log file: the last 300 lines on connect, then appended lines each tick. */
+    private void handleLogEvents(HttpServerRequest aRequest) {
+        HttpServerResponse response = aRequest.response();
+        response.setChunked(true);
+        response.putHeader("Content-Type", "text/event-stream");
+        response.putHeader("Cache-Control", "no-cache");
+        response.putHeader("Connection", "keep-alive");
+
+        if (serverLogFile == null || serverLogFile.isBlank()) {
+            writeEvent(response, "logline", "<div class=\"log-row\">server log is not configured (SERVER_LOG_FILE)</div>");
+            response.end();
+            return;
+        }
+
+        ServerLogTailer tailer = new ServerLogTailer(new File(serverLogFile));
+        long[] offset = {0};
+
+        vertx.<List<String>>executeBlocking(() -> {
+            List<String> initial = tailer.lastLines(300);
+            offset[0] = tailer.size();
+            return initial;
+        }, false).onComplete(ar -> {
+            if (ar.succeeded() && !response.closed() && !response.ended()) {
+                writeEvent(response, "logline", logRows(ar.result()));
+            }
+        });
+
+        long timerId = vertx.setPeriodic(refreshMs, id -> {
+            if (response.closed() || response.ended()) {
+                vertx.cancelTimer(id);
+                return;
+            }
+            vertx.<ServerLogTailer.Chunk>executeBlocking(() -> tailer.readFrom(offset[0]), false).onComplete(ar -> {
+                if (ar.failed()) {
+                    return;
+                }
+                ServerLogTailer.Chunk chunk = ar.result();
+                offset[0] = chunk.offset();
+                if (!chunk.lines().isEmpty() && !response.closed() && !response.ended()) {
+                    writeEvent(response, "logline", logRows(chunk.lines()));
+                }
+            });
+        });
+
+        aRequest.connection().closeHandler(aVoid -> vertx.cancelTimer(timerId));
+    }
+
+    private static String logRows(List<String> aLines) {
+        StringBuilder sb = new StringBuilder();
+        for (String line : aLines) {
+            sb.append("<div class=\"log-row\">").append(DashboardView.esc(line)).append("</div>");
+        }
+        return sb.toString();
     }
 
     /** Writes one snapshot of every card; returns false if the client connection is gone. */

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -147,6 +147,7 @@ public final class DashboardView {
         for (AgentLogBuffer.LogLine line : aLines) {
             String time = LOG_TIME.format(Instant.ofEpochMilli(line.epochMs()).atZone(ZoneId.systemDefault()));
             sb.append("<div class=\"logline\"><span class=\"log-time\">").append(time).append("</span>")
+              .append("<span class=\"log-agent\">").append(esc(line.agentId())).append("</span>")
               .append("<code class=\"log-id\">#").append(esc(shortId(line.commandId()))).append("</code>")
               .append("<span class=\"log-msg\">").append(esc(line.message())).append("</span>")
               .append("</div>");

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/IDashboardConfig.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/IDashboardConfig.java
@@ -10,4 +10,8 @@ public interface IDashboardConfig extends IStartupConfig {
 
     @AStartupParameter(name = "DASHBOARD_REFRESH_MS", value = "2000")
     long refreshMs();
+
+    /** Server log file tailed on the dashboard "Log" screen. Blank disables the screen. */
+    @AStartupParameter(name = "SERVER_LOG_FILE", value = "/var/log/deploy-server-1/current")
+    String serverLogFile();
 }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/ServerLogTailer.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/ServerLogTailer.java
@@ -1,0 +1,87 @@
+package io.pne.deploy.server.vertx.dashboard;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tails a plain-text log file for the dashboard "Log" screen: an initial "last N lines" read plus cheap
+ * incremental reads of the bytes appended since a byte offset. Handles rotation/truncation (svlogd renames
+ * {@code current}): if the file shrank below the last offset, reading restarts from the beginning. Not
+ * thread-safe — each SSE connection uses its own instance (it carries an incomplete trailing line between reads).
+ */
+public class ServerLogTailer {
+
+    private static final int MAX_READ = 1_000_000;
+
+    private final File          file;
+    private final StringBuilder partial = new StringBuilder(); // incomplete trailing line carried between reads
+
+    public ServerLogTailer(File aFile) {
+        this.file = aFile;
+    }
+
+    /** Last {@code aCount} lines of the file (whole-file read; the log is small, a few MB at most). */
+    public List<String> lastLines(int aCount) {
+        if (file == null || !file.isFile()) {
+            return List.of();
+        }
+        try {
+            List<String> all = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
+            int from = Math.max(0, all.size() - aCount);
+            return new ArrayList<>(all.subList(from, all.size()));
+        } catch (IOException e) {
+            return List.of("(cannot read " + file + ": " + e.getMessage() + ")");
+        }
+    }
+
+    public long size() {
+        return file == null ? 0 : file.length();
+    }
+
+    /** Complete lines appended since {@code aOffset}; returns the offset to continue from. Resets to 0 on truncation. */
+    public Chunk readFrom(long aOffset) {
+        if (file == null || !file.isFile()) {
+            return new Chunk(List.of(), aOffset);
+        }
+        long length = file.length();
+        long offset = aOffset;
+        if (length < offset) { // rotated / truncated -> start over
+            offset = 0;
+            partial.setLength(0);
+        }
+        if (length <= offset) {
+            return new Chunk(List.of(), offset);
+        }
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            raf.seek(offset);
+            byte[] buf = new byte[(int) Math.min(length - offset, MAX_READ)];
+            int read = raf.read(buf);
+            if (read <= 0) {
+                return new Chunk(List.of(), offset);
+            }
+            partial.append(new String(buf, 0, read, StandardCharsets.UTF_8));
+            List<String> lines = new ArrayList<>();
+            int nl;
+            while ((nl = partial.indexOf("\n")) >= 0) {
+                String line = partial.substring(0, nl);
+                if (line.endsWith("\r")) {
+                    line = line.substring(0, line.length() - 1);
+                }
+                lines.add(line);
+                partial.delete(0, nl + 1);
+            }
+            return new Chunk(lines, offset + read);
+        } catch (IOException e) {
+            return new Chunk(List.of(), offset);
+        }
+    }
+
+    /** Appended complete lines plus the offset to continue reading from. */
+    public record Chunk(List<String> lines, long offset) {
+    }
+}

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -161,8 +161,17 @@
                    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; line-height: 1.7; }
         .logline:hover { background: var(--card-head); }
         .log-time { flex: 0 0 auto; color: var(--argnum); font-variant-numeric: tabular-nums; }
+        .log-agent { flex: 0 0 auto; color: var(--accent); }
         .log-id { flex: 0 0 auto; color: var(--muted); }
         .log-msg { min-width: 0; color: var(--fg); white-space: pre-wrap; word-break: break-word; }
+
+        /* server log screen */
+        .log-card { flex: 1 1 auto; display: flex; flex-direction: column; min-height: 340px; }
+        .log-view { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 8px 0; background: var(--bg); }
+        .log-stream { display: flex; flex-direction: column; }
+        .log-row { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; line-height: 1.55;
+                   white-space: pre-wrap; word-break: break-word; padding: 0 16px; color: var(--fg); }
+        .log-row:hover { background: var(--card-head); }
 
         /* ---- Config screen ---- */
         .cfg-root { display: flex; flex-direction: column; gap: 16px; }
@@ -277,6 +286,7 @@
         <button class="tab active" data-screen="live">Live</button>
         <button class="tab" data-screen="config">Config</button>
         <button class="tab" data-screen="aliases">Aliases</button>
+        <button class="tab" data-screen="log">Log</button>
         <button class="tab theme-toggle" id="theme-btn" type="button" title="Toggle light / dark theme" aria-label="Toggle theme">&#9680;</button>
     </nav>
 
@@ -323,6 +333,15 @@
         </div>
     </section>
 
+    <section id="screen-log" class="screen" hidden>
+        <section class="card flush log-card">
+            <div class="card-head">Server log</div>
+            <div class="log-view" hx-ext="sse" sse-connect="{{BASE}}/log/events">
+                <div class="log-stream" sse-swap="logline" hx-swap="beforeend"></div>
+            </div>
+        </section>
+    </section>
+
     <script>
         (function () {
             var root = document.documentElement;
@@ -367,7 +386,7 @@
 
         (function () {
             var tabs    = document.querySelectorAll('.tab');
-            var screens = { live: 'screen-live', config: 'screen-config', aliases: 'screen-aliases' };
+            var screens = { live: 'screen-live', config: 'screen-config', aliases: 'screen-aliases', log: 'screen-log' };
             tabs.forEach(function (tab) {
                 tab.addEventListener('click', function () {
                     if (!tab.getAttribute('data-screen')) { return; }
@@ -445,6 +464,24 @@
                 t.classList.toggle('active');
                 apply();
             });
+        })();
+
+        (function () {
+            var view = document.querySelector('#screen-log .log-view');
+            var stream = document.querySelector('#screen-log .log-stream');
+            if (!view || !stream) { return; }
+            var MAX_ROWS = 1000;
+            stream.addEventListener('htmx:afterSwap', function () {
+                while (stream.children.length > MAX_ROWS) { stream.removeChild(stream.firstChild); }
+                var nearBottom = view.scrollHeight - view.scrollTop - view.clientHeight < 60;
+                if (nearBottom) { view.scrollTop = view.scrollHeight; }
+            });
+            var logTab = document.querySelector('.tab[data-screen="log"]');
+            if (logTab) {
+                logTab.addEventListener('click', function () {
+                    setTimeout(function () { view.scrollTop = view.scrollHeight; }, 0);
+                });
+            }
         })();
     </script>
 </body>

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/TestServerApplicationListener.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/TestServerApplicationListener.java
@@ -34,7 +34,7 @@ public class TestServerApplicationListener implements IServerApplicationListener
         }
     }
 
-    public <T extends IAgentClientMessage> void didReceiveMessage(T aMessage) {
+    public <T extends IAgentClientMessage> void didReceiveMessage(String aAgentId, T aMessage) {
         messages.add(aMessage);
     }
 

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/AgentLogBufferTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/AgentLogBufferTest.java
@@ -12,10 +12,10 @@ public class AgentLogBufferTest {
     @Test
     public void keepsMostRecentUpToCapacityNewestFirst() {
         AgentLogBuffer buffer = new AgentLogBuffer(3);
-        buffer.add("c", "one");
-        buffer.add("c", "two");
-        buffer.add("c", "three");
-        buffer.add("c", "four"); // evicts "one"
+        buffer.add("a", "c","one");
+        buffer.add("a", "c","two");
+        buffer.add("a", "c","three");
+        buffer.add("a", "c","four"); // evicts "one"
 
         List<AgentLogBuffer.LogLine> snap = buffer.snapshot(10);
         assertEquals(3, snap.size());
@@ -28,7 +28,7 @@ public class AgentLogBufferTest {
     public void snapshotRespectsMax() {
         AgentLogBuffer buffer = new AgentLogBuffer(100);
         for (int i = 0; i < 10; i++) {
-            buffer.add("c", "m" + i);
+            buffer.add("a", "c","m" + i);
         }
         List<AgentLogBuffer.LogLine> snap = buffer.snapshot(3);
         assertEquals(3, snap.size());

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -140,11 +140,12 @@ public class DashboardViewTest {
     @Test
     public void logsRenderMessagesNewestFirstAndEscape() {
         AgentLogBuffer buffer = new AgentLogBuffer(10);
-        buffer.add("cmd-123456789", "first line");
-        buffer.add("cmd-123456789", "<script>bad</script>");
+        buffer.add("dui-1", "cmd-123456789", "first line");
+        buffer.add("dui-1", "cmd-123456789", "<script>bad</script>");
 
         String html = DashboardView.logs(buffer.snapshot(10));
         assertTrue(html, html.contains("first line"));
+        assertTrue(html, html.contains("dui-1")); // source agent is shown
         assertTrue(html, html.contains("&lt;script&gt;bad&lt;/script&gt;"));
         assertFalse(html, html.contains("<script>bad"));
         assertTrue(html, html.contains("logbox"));

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/ServerLogTailerTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/ServerLogTailerTest.java
@@ -1,0 +1,67 @@
+package io.pne.deploy.server.vertx.dashboard;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ServerLogTailerTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void lastLinesReturnsTail() throws Exception {
+        File f = write("l1\nl2\nl3\nl4\nl5\n");
+        assertEquals(List.of("l3", "l4", "l5"), new ServerLogTailer(f).lastLines(3));
+    }
+
+    @Test
+    public void readFromReturnsOnlyNewCompleteLinesAndAdvancesOffset() throws Exception {
+        File f = write("a\nb\n");
+        ServerLogTailer tailer = new ServerLogTailer(f);
+        long offset = f.length();
+
+        append(f, "c\nd\ne-part");                 // two full lines + a partial (no trailing newline yet)
+        ServerLogTailer.Chunk chunk = tailer.readFrom(offset);
+        assertEquals(List.of("c", "d"), chunk.lines()); // "e-part" is withheld until its line completes
+
+        append(f, "-done\n");
+        ServerLogTailer.Chunk chunk2 = tailer.readFrom(chunk.offset());
+        assertEquals(List.of("e-part-done"), chunk2.lines());
+    }
+
+    @Test
+    public void shrinkingFileResetsToStart() throws Exception {
+        File f = write("one\ntwo\nthree\n");
+        ServerLogTailer tailer = new ServerLogTailer(f);
+        long offset = f.length();
+
+        write(f, "fresh\n"); // rotation: file replaced with a shorter one
+        ServerLogTailer.Chunk chunk = tailer.readFrom(offset);
+        assertTrue(chunk.lines().toString(), chunk.lines().contains("fresh"));
+    }
+
+    private File write(String content) throws IOException {
+        File f = tmp.newFile();
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
+        return f;
+    }
+
+    private void write(File f, String content) throws IOException {
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
+    }
+
+    private void append(File f, String content) throws IOException {
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+    }
+}

--- a/server/src/main/java/io/pne/deploy/server/IServerApplicationListener.java
+++ b/server/src/main/java/io/pne/deploy/server/IServerApplicationListener.java
@@ -7,7 +7,7 @@ public interface IServerApplicationListener {
 
     void didStarted();
 
-    <T extends IAgentClientMessage> void didReceiveMessage(T aMessage);
+    <T extends IAgentClientMessage> void didReceiveMessage(String aAgentId, T aMessage);
 
     void didStartFailed(Throwable cause);
 }


### PR DESCRIPTION
Three diff/dashboard diagnosability changes (from the deploy-05 log + dashboard follow-ups).

## 1. Fix GitLab compare URL + log status/body on error
- **Bug:** the compare URL was `https://code.clubber.me/git/git/api/v4/projects/…` — a doubled `/git`, because `GITLAB_URL` already carries the custom `/git` prefix and `API_1` prepended another. Fixed `API_1 = "/api/v4/projects/"`.
- On any error the HTTP **status** and a **truncated response body** are now logged and included in the thrown exception: non-200 → `LOG.warn("Gitlab compare: HTTP {} for {} — body: {}")`; a 200 body that isn't valid JSON is caught and logged the same way (previously only the gson stack trace, no status/body). The API key stays in the `Authorization` header, never logged.
- Extracted `compareUrl(DiffTask)` + an injectable test ctor.

## 2. Show the source agent on the dashboard "Agent logs"
The agent id is known per websocket connection but wasn't threaded to the log capture. Plumbed it socket → `didReceiveMessage(agentId, msg)` → `AgentLogBuffer.add(agentId, …)` → `DashboardView.logs` renders a `.log-agent` span. Server log line also enriched (`AgentLog` now `"<agent> <commandId>: <message>"`).

## 3. New "Log" tab — tail of the server log file
- `IDashboardConfig.serverLogFile()` (`SERVER_LOG_FILE`, default `/var/log/deploy-server-1/current`; blank disables the screen).
- `ServerLogTailer`: last-N-lines read + cheap incremental `readFrom(offset)` (RandomAccessFile), holding a partial trailing line between reads, resetting on truncation/rotation.
- `DashboardHttpHandler` SSE endpoint `<base>/log/events`: sends the last 300 lines on connect, then appended lines each tick (file IO off the event loop via `executeBlocking`).
- New **Log** tab / `#screen-log` with its own SSE connection, `hx-swap="beforeend"` append, auto-scroll-to-bottom, and a client-side row cap (1000) to bound DOM growth.

## Tests
- `RemoteGitlabServiceImplTest`: `compareUrl` is single-`/git`; non-200 and unparseable-200 bodies throw with status+body snippet.
- `AgentLogBufferTest` / `DashboardViewTest`: agent id in the buffer + rendered.
- `ServerLogTailerTest`: tail, incremental new-lines + offset, truncation reset.
- `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS.

## Note
The server-log page has no app-level auth (dashboard auth is at the proxy) and exposes log contents — consistent with the existing dashboard model; the path is fixed by config (no traversal).