### PR TITLE
fix(dashboard): render server log via hx-get and show a reason when empty

### DIFF
--- a/integration-test/src/test/java/io/pne/deploy/tests/DashboardHttpTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/DashboardHttpTest.java
@@ -73,6 +73,12 @@ public class DashboardHttpTest {
             assertTrue("proxy-rewritten GET must not be 405, got: " + rewritten, rewritten.startsWith("HTTP/1.1 200"));
             assertTrue("GET with body should enqueue the id, got: " + rewritten, rewritten.contains("#888"));
 
+            // 3c. the Log screen initial content always renders a reason instead of a silent blank
+            HttpResponse<String> log = client.send(get("/deploy/dashboard/log"), ofString());
+            assertEquals(200, log.statusCode());
+            assertTrue("log should explain why it is empty, got: " + log.body(),
+                    log.body().contains("server log is not configured"));
+
             // 4. the live SSE stream — first snapshot (all cards) must arrive immediately
             HttpResponse<InputStream> events = client.send(get("/deploy/dashboard/events"), ofInputStream());
             assertEquals(200, events.statusCode());

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -71,6 +71,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     private final String configPath;
     private final String aliasesPath;
     private final String aliasPath;
+    private final String logPath;
     private final String logEventsPath;
 
     private final Buffer indexHtml;
@@ -112,6 +113,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         this.configPath  = basePath + "/config";
         this.aliasesPath = basePath + "/aliases";
         this.aliasPath   = basePath + "/alias";
+        this.logPath       = basePath + "/log";
         this.logEventsPath = basePath + "/log/events";
 
         this.indexHtml = Buffer.buffer(readResourceString("/dashboard/index.html").replace("{{BASE}}", basePath));
@@ -139,6 +141,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             handleAliasList(aRequest);
         } else if (aliasPath.equals(path)) {
             handleAliasDetail(aRequest, aRequest.getParam("name"));
+        } else if (logPath.equals(path)) {
+            handleLog(aRequest);
         } else if (logEventsPath.equals(path)) {
             handleLogEvents(aRequest);
         } else if (basePath.equals(path) || (basePath + "/").equals(path)) {
@@ -280,7 +284,33 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         aRequest.connection().closeHandler(aVoid -> vertx.cancelTimer(timerId));
     }
 
-    /** SSE tail of the configured server log file: the last 300 lines on connect, then appended lines each tick. */
+    /** Initial Log-screen content: the last 300 lines, or a plain reason when there is nothing to show. */
+    private void handleLog(HttpServerRequest aRequest) {
+        vertx.<String>executeBlocking(() -> {
+            List<String> rows = new ServerLogTailer(new File(serverLogFile == null ? "" : serverLogFile)).lastLines(300);
+            return logRows(rows.isEmpty() ? List.of(logDiagnostic()) : rows);
+        }, false).onComplete(ar -> {
+            String html = ar.succeeded() ? ar.result() : logRows(List.of(logDiagnostic()));
+            serve(aRequest, "text/html; charset=utf-8", Buffer.buffer(html));
+        });
+    }
+
+    /** Why the Log screen has nothing to show, so it is never silently blank. */
+    private String logDiagnostic() {
+        if (serverLogFile == null || serverLogFile.isBlank()) {
+            return "server log is not configured (SERVER_LOG_FILE)";
+        }
+        File file = new File(serverLogFile);
+        if (!file.exists()) {
+            return "log file " + serverLogFile + " does not exist";
+        }
+        if (!file.canRead()) {
+            return "cannot read log file " + serverLogFile;
+        }
+        return "log file " + serverLogFile + " is empty";
+    }
+
+    /** SSE tail: only the lines appended since connect (the initial view is served by GET {base}/log). */
     private void handleLogEvents(HttpServerRequest aRequest) {
         HttpServerResponse response = aRequest.response();
         response.setChunked(true);
@@ -288,24 +318,8 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
         response.putHeader("Cache-Control", "no-cache");
         response.putHeader("Connection", "keep-alive");
 
-        if (serverLogFile == null || serverLogFile.isBlank()) {
-            writeEvent(response, "logline", "<div class=\"log-row\">server log is not configured (SERVER_LOG_FILE)</div>");
-            response.end();
-            return;
-        }
-
-        ServerLogTailer tailer = new ServerLogTailer(new File(serverLogFile));
-        long[] offset = {0};
-
-        vertx.<List<String>>executeBlocking(() -> {
-            List<String> initial = tailer.lastLines(300);
-            offset[0] = tailer.size();
-            return initial;
-        }, false).onComplete(ar -> {
-            if (ar.succeeded() && !response.closed() && !response.ended()) {
-                writeEvent(response, "logline", logRows(ar.result()));
-            }
-        });
+        ServerLogTailer tailer = new ServerLogTailer(new File(serverLogFile == null ? "" : serverLogFile));
+        long[] offset = {tailer.size()}; // continue from the current end; GET /log already showed the tail
 
         long timerId = vertx.setPeriodic(refreshMs, id -> {
             if (response.closed() || response.ended()) {

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -336,8 +336,9 @@
     <section id="screen-log" class="screen" hidden>
         <section class="card flush log-card">
             <div class="card-head">Server log</div>
-            <div class="log-view" hx-ext="sse" sse-connect="{{BASE}}/log/events">
-                <div class="log-stream" sse-swap="logline" hx-swap="beforeend"></div>
+            <div class="log-view" sse-connect="{{BASE}}/log/events">
+                <div class="log-stream" hx-get="{{BASE}}/log" hx-trigger="load"><span class="muted" style="display:block; padding:8px 16px">loading&hellip;</span></div>
+                <div class="log-tail" sse-swap="logline" hx-swap="beforeend"></div>
             </div>
         </section>
     </section>
@@ -468,12 +469,12 @@
 
         (function () {
             var view = document.querySelector('#screen-log .log-view');
-            var stream = document.querySelector('#screen-log .log-stream');
-            if (!view || !stream) { return; }
+            var tail = document.querySelector('#screen-log .log-tail');
+            if (!view) { return; }
             var MAX_ROWS = 1000;
-            stream.addEventListener('htmx:afterSwap', function () {
-                while (stream.children.length > MAX_ROWS) { stream.removeChild(stream.firstChild); }
-                var nearBottom = view.scrollHeight - view.scrollTop - view.clientHeight < 60;
+            view.addEventListener('htmx:afterSwap', function () {
+                if (tail) { while (tail.children.length > MAX_ROWS) { tail.removeChild(tail.firstChild); } }
+                var nearBottom = view.scrollHeight - view.scrollTop - view.clientHeight < 80;
                 if (nearBottom) { view.scrollTop = view.scrollHeight; }
             });
             var logTab = document.querySelector('.tab[data-screen="log"]');


### PR DESCRIPTION
## Problem
The **Log** tab showed an empty panel with no error and no explanation. The `/log/events` SSE handler sent the last-300-lines as the *initial* event, but when the configured file is missing/empty (`SERVER_LOG_FILE` default may not match the real path on the box, or be unreadable), the initial event was empty → htmx appended nothing → a silent blank.

## Change
- Initial view now loads via **`GET {base}/log`** with `hx-get`+`hx-trigger="load"` — the same proven mechanism the Config/Aliases screens use — so the last 300 lines *or a clear reason* always render, independent of SSE.
- **`logDiagnostic()`** surfaces the reason when there's nothing to show: `server log is not configured`, `log file <path> does not exist`, `cannot read log file <path>`, or `log file <path> is empty`.
- `/log/events` SSE now tails **only new appended lines** (offset = current size on connect); the initial view is owned by `GET /log`, so no duplication.
- `#screen-log` split into a `.log-stream` (hx-get initial) and a `.log-tail` (`sse-swap` append) inside the scroll box; JS auto-scrolls and caps rows.

## Tests
- `DashboardHttpTest`: the test server has `SERVER_LOG_FILE == ""`, so `GET /deploy/dashboard/log` must return 200 with `server log is not configured` (route works + always shows a reason).
- Booted the server against a temp log file and confirmed end-to-end: `GET /log` renders the rows; `/log/events` streams a `logline` event after an append; removing the file makes `/log` show `log file <path> does not exist`.
- `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS.

## Note for deployment
If the Log tab shows `log file … does not exist`, set `SERVER_LOG_FILE` to the actual server log path and restart.