### PR TITLE
fix(redmine): null-safe issue mapping for missing custom fields and assignee

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImpl.java
@@ -263,22 +263,30 @@ public class RemoteRedmine4_2_10ServiceImpl implements IRemoteRedmineService {
         }
     }
 
-    private ImmutableRedmineIssue mapIssue(RedmineIssueData issue) {
+    // Null-safe: an arbitrary issue (e.g. one referenced from a commit message for the diff) may omit
+    // custom_fields / assigned_to / etc. in the Redmine JSON, while RedmineIssue requires every field.
+    static RedmineIssue mapIssue(RedmineIssueData issue) {
         Map<String, String> customFields = new HashMap<>();
-        for (CustomFields redmineCustomField : issue.getCustomFields()) {
-            customFields.put(redmineCustomField.getName(), redmineCustomField.getValue());
+        if (issue.getCustomFields() != null) {
+            for (CustomFields redmineCustomField : issue.getCustomFields()) {
+                customFields.put(redmineCustomField.getName(), redmineCustomField.getValue());
+            }
         }
+        var status   = issue.getStatus();
+        var project  = issue.getProject();
+        var author   = issue.getAuthor();
+        var assignee = issue.getAssigned_to();
         return ImmutableRedmineIssue.builder()
                 .issueId        ( issue.getId())
-                .description    ( issue.getDescription())
-                .subject        ( issue.getSubject())
-                .statusName     ( issue.getStatus().getName())
-                .statusId       ( issue.getStatus().getId())
-                .projectId      ( issue.getProject().getId())
-                .projectName    ( issue.getProject().getName())
+                .description    ( issue.getDescription() == null ? "" : issue.getDescription())
+                .subject        ( issue.getSubject() == null ? "" : issue.getSubject())
+                .statusName     ( status == null ? "" : status.getName())
+                .statusId       ( status == null ? 0  : status.getId())
+                .projectId      ( project == null ? 0  : project.getId())
+                .projectName    ( project == null ? "" : project.getName())
                 .customFields   ( customFields)
-                .assigneeName   ( issue.getAssigned_to().getName())
-                .creatorName    ( issue.getAuthor().getName())
+                .assigneeName   ( assignee == null ? "" : assignee.getName())
+                .creatorName    ( author == null ? "" : author.getName())
                 .build();
     }
 

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImplTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/remote/impl/RemoteRedmine4_2_10ServiceImplTest.java
@@ -2,10 +2,29 @@ package io.pne.deploy.client.redmine.remote.impl;
 
 import com.payneteasy.startup.parameters.StartupParametersFactory;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
+import io.pne.deploy.client.redmine.remote.data_model.RedmineIssueData;
+import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class RemoteRedmine4_2_10ServiceImplTest {
+
+    @Test
+    public void mapIssueToleratesMissingCustomFieldsAndAssignee() {
+        // Redmine omits custom_fields / assigned_to for issues that have none; must not NPE.
+        RedmineIssueData data = RedmineIssueData.builder()
+                .id(167994)
+                .subject("Referenced issue")
+                .build();
+        RedmineIssue issue = RemoteRedmine4_2_10ServiceImpl.mapIssue(data);
+        assertEquals(167994, issue.issueId());
+        assertEquals("Referenced issue", issue.subject());
+        assertTrue("custom fields default to empty", issue.customFields().isEmpty());
+        assertEquals("assignee defaults to empty", "", issue.assigneeName());
+    }
     @Test
     @Ignore
     public void getCommentTest() {


### PR DESCRIPTION
## Problem
The `redmine-diff` thread logs `Can't load Redmine issue subject for 167994` with
`NullPointerException: … RedmineIssueData.getCustomFields() is null` at `RemoteRedmine4_2_10ServiceImpl.mapIssue`.

`DiffServiceImpl.mapDiffIssues` resolves `#NNN` references in commit messages to a subject via `redmine.getIssue(id).subject()`. `getIssue` → `mapIssue`, which iterated `issue.getCustomFields()` unconditionally. Redmine's `/issues/N.json` omits `custom_fields` when an issue has none (and `assigned_to` for unassigned issues), so gson leaves them null → NPE. `RedmineIssue` (`@Value.Immutable`) makes every field mandatory, so `mapIssue` also assumed `assigned_to`/`status`/`project`/`author`/`description` were non-null — any of which can be null for an arbitrary referenced issue. The deploy issue always has these, so the main path was fine; only the diff's referenced issues blew up. It was caught (WARN + fallback to the raw commit message) — non-fatal, but noisy and it dropped the subject.

## Change
`mapIssue` is now null-safe with sensible defaults (empty custom fields, `""`/`0` for missing status/project/assignee/author/description), so `getIssue` returns a valid `RedmineIssue` for any issue → the diff loads the real subject and the WARN/stacktrace stop. The deploy path is unchanged (its issues have all fields, so defaults never trigger; and if one ever lacked approvals it now maps to empty custom fields → the validation script returns `false` instead of crashing — safer). No interface change; `DiffServiceImpl` and the diff mock are untouched. `mapIssue` is made `static` + package-private so it's directly unit-testable.

## Test
`RemoteRedmine4_2_10ServiceImplTest.mapIssueToleratesMissingCustomFieldsAndAssignee`: a bare `RedmineIssueData` (no `custom_fields`, no `assigned_to`, no status/project/author) maps without throwing, preserves `issueId`/`subject`, and defaults custom fields to empty and `assigneeName` to `""`.

`mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS.