### PR TITLE
feat(diff): drive diff from Task.diff config instead of command arguments

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
@@ -11,7 +11,7 @@ import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
 import io.pne.deploy.client.redmine.remote.impl.RemoteGitlabServiceImpl;
 import io.pne.deploy.client.redmine.remote.impl.RemoteTelegramServiceImpl;
 import io.pne.deploy.server.api.task.Task;
-import io.pne.deploy.server.api.task.TaskCommand;
+import io.pne.deploy.server.api.task.TaskDiff;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +25,6 @@ import java.util.regex.Pattern;
 
 public class DiffServiceImpl implements DiffService {
     private static final Logger LOG = LoggerFactory.getLogger(DiffServiceImpl.class);
-    private static final Pattern LINK_LIKE = Pattern.compile("^(https?://|http:).+");
-    private static final Pattern VERSION_LIKE = Pattern.compile("^\\d+(?:\\.\\d+){2}(?:-\\d+)?$");
-    private static final Pattern GITLAB_PROJECT_LIKE = Pattern.compile("^gitlab=(\\d+)$");
     private static final Pattern REDMINE_ISSUE_LIKE = Pattern.compile("#(\\d+)");
     private static final int TG_SAFE_MAX = 4000;
 
@@ -84,53 +81,42 @@ public class DiffServiceImpl implements DiffService {
     }
 
     public List<DiffTask> getCurrentVersion(Task task) {
-        List<DiffTask> diffTasks = new ArrayList<>();
-        if (task == null || task.commands.isEmpty()) {
-            LOG.info("Diff: no task/commands, nothing to diff");
+        if (task == null || task.diff == null || !task.diff.isEnabled()) {
+            LOG.info("Diff: no enabled diff config for '{}'", task == null ? null : task.taskLine);
+            return new ArrayList<>();
+        }
+        TaskDiff diff = task.diff;
+        String newVersion = taskVersion(task.taskLine);
+        if (newVersion == null) {
+            LOG.info("Diff: skip '{}' — no version in the task line", task.taskLine);
+            return new ArrayList<>();
+        }
+        try {
+            String oldVersion = getUrlContent(diff.getVersionUrl());
+            if (oldVersion == null || oldVersion.isEmpty()) {
+                LOG.info("Diff: skip '{}' — old version is empty from {}", task.taskLine, diff.getVersionUrl());
+                return new ArrayList<>();
+            }
+            String[] agents = diff.getAgent() == null || diff.getAgent().isBlank()
+                    ? new String[0] : new String[]{diff.getAgent()};
+            LOG.info("Diff: '{}' — gitlabProjectId={}, {} -> {}, agent={}",
+                    task.taskLine, diff.getGitlabProjectId(), oldVersion, newVersion, diff.getAgent());
+            List<DiffTask> diffTasks = new ArrayList<>();
+            diffTasks.add(new DiffTask(agents, diff.getGitlabProjectId(), task.taskLine, oldVersion, newVersion));
             return diffTasks;
+        } catch (Exception e) {
+            LOG.error("Diff: can't build diff task for '{}'", task.taskLine, e);
+            return new ArrayList<>();
         }
-        // A command is diff-eligible purely by its arguments: a version, an old-version url, and a gitlab=<id>.
-        LOG.info("Diff: scanning {} command(s) of '{}' (need version + url + gitlab=<id>)",
-                task.commands.size(), task.taskLine);
-        for (TaskCommand command : task.commands) {
-            if (command == null) {
-                continue;
-            }
-            String name = command.command.name;
-            try {
-                String newVersion = parseStringFromArguments(command.command.arguments, VERSION_LIKE);
-                if (newVersion == null) {
-                    LOG.info("Diff: skip '{}' — no version argument", name);
-                    continue;
-                }
-                String linkForOldVersion = parseStringFromArguments(command.command.arguments, LINK_LIKE);
-                if (linkForOldVersion == null) {
-                    LOG.info("Diff: skip '{}' — no old-version url argument", name);
-                    continue;
-                }
-                Integer gitlabProject = parseGitlabProjectFromArguments(command.command.arguments);
-                if (gitlabProject == null) {
-                    LOG.info("Diff: skip '{}' — no gitlab=<id> argument", name);
-                    continue;
-                }
-                String oldVersion = getUrlContent(linkForOldVersion);
-                if (oldVersion == null || oldVersion.isEmpty()) {
-                    LOG.info("Diff: skip '{}' — old version is empty from {}", name, linkForOldVersion);
-                    continue;
-                }
-                LOG.info("Diff: include '{}' — gitlab={}, {} -> {}, agents={}",
-                        name, gitlabProject, oldVersion, newVersion, Arrays.toString(command.agents.getIds()));
-                diffTasks.add(new DiffTask(command.agents.getIds(),
-                        gitlabProject,
-                        task.taskLine,
-                        oldVersion,
-                        newVersion));
-            } catch (Exception e) {
-                LOG.error("Diff: can't build diff task for command '{}'", name, e);
-            }
+    }
+
+    /** The deploy version is the first parameter of the task line ("&lt;alias&gt; &lt;version&gt; ..."). */
+    private static String taskVersion(String taskLine) {
+        if (taskLine == null) {
+            return null;
         }
-        LOG.info("Diff: {} diff task(s) built for '{}'", diffTasks.size(), task.taskLine);
-        return diffTasks;
+        String[] tokens = taskLine.trim().split("\\s+");
+        return tokens.length >= 2 ? tokens[1] : null;
     }
 
     Map<DiffKey, DiffTask> aggregate(List<DiffTask> tasks) {
@@ -276,27 +262,6 @@ public class DiffServiceImpl implements DiffService {
         Matcher m = REDMINE_ISSUE_LIKE.matcher(message);
         if (m.find()) {
             return Integer.parseInt(m.group(1));
-        }
-        return null;
-    }
-
-    private Integer parseGitlabProjectFromArguments(List<String> arguments) {
-        if (arguments == null || arguments.isEmpty()) return null;
-        for (String s : arguments) {
-            Matcher m = GITLAB_PROJECT_LIKE.matcher(s);
-            if (m.matches()) {
-                return Integer.parseInt(m.group(1));
-            }
-        }
-        return null;
-    }
-
-    private String parseStringFromArguments(List<String> arguments, Pattern pattern) {
-        if (arguments == null || arguments.isEmpty()) return null;
-        for (String s : arguments) {
-            if (pattern.matcher(s).matches()) {
-                return s;
-            }
         }
         return null;
     }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
@@ -143,6 +143,7 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
                 , stub.commands
                 , text
                 , aIssueId
+                , stub.diff
         );
     }
 }

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
@@ -5,12 +5,8 @@ import io.pne.deploy.client.redmine.remote.IRemoteGitlabService;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
-import io.pne.deploy.agent.api.command.AgentCommand;
-import io.pne.deploy.agent.api.command.AgentCommandParameters;
-import io.pne.deploy.agent.api.command.AgentCommandType;
-import io.pne.deploy.server.api.task.AgentFinder;
 import io.pne.deploy.server.api.task.Task;
-import io.pne.deploy.server.api.task.TaskCommand;
+import io.pne.deploy.server.api.task.TaskDiff;
 import io.pne.deploy.server.api.task.TaskId;
 import io.pne.deploy.server.api.task.TaskParameters;
 import com.sun.net.httpserver.HttpServer;
@@ -79,11 +75,11 @@ public class DiffServiceProcessDiffTest {
     }
 
     /**
-     * Diff-eligibility is decided purely by the arguments (version + old-version url + gitlab=&lt;id&gt;), not by
-     * the script name: a "sandbox" command with a gitlab token is now included, and one without a token is not.
+     * The diff is driven by {@code task.diff} (versionUrl / gitlabProjectId / agent), not by command arguments;
+     * newVersion is the first parameter of the task line. Old version is fetched from the diff's versionUrl.
      */
     @Test
-    public void getCurrentVersionSelectsByGitlabTokenNotName() throws Exception {
+    public void getCurrentVersionUsesTaskDiff() throws Exception {
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/version", exchange -> {
             byte[] body = "3.36.16-42\n".getBytes(UTF_8);
@@ -93,32 +89,35 @@ public class DiffServiceProcessDiffTest {
             }
         });
         server.start();
-        String oldVersionUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/version";
+        String versionUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/version";
         try {
-            // name contains "sandbox" but has version + url + gitlab=114 -> must be INCLUDED
-            TaskCommand ui = new TaskCommand(
-                    new AgentFinder(new String[]{"dui-1"}),
-                    new AgentCommand(new AgentCommandParameters(), AgentCommandType.SHELL,
-                            "./bin/redeploy-sandbox-ui.sh",
-                            Arrays.asList("3.36.16-100", oldVersionUrl, "gitlab=114")));
-            // no url, no gitlab token -> must be EXCLUDED
-            TaskCommand skin = new TaskCommand(
-                    new AgentFinder(new String[]{"dpub-2"}),
-                    new AgentCommand(new AgentCommandParameters(), AgentCommandType.SHELL,
-                            "./bin/redeploy-sandbox-skin.sh",
-                            singletonList("3.36.16-100")));
+            TaskDiff diff = TaskDiff.builder()
+                    .enabled(true).versionUrl(versionUrl).gitlabProjectId(42).agent("agent-1").build();
             Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
-                    Arrays.asList(ui, skin), "msk-sandbox-ui 3.36.16-100", 168059);
+                    Collections.emptyList(), "demo 3.36.16-100", 168059, diff);
 
             List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
 
-            assertEquals("only the command carrying gitlab=<id> is eligible", 1, diffTasks.size());
+            assertEquals(1, diffTasks.size());
             DiffTask built = diffTasks.get(0);
-            assertEquals(Integer.valueOf(114), built.getGitlabProject());
+            assertEquals(Integer.valueOf(42), built.getGitlabProject());
             assertEquals("3.36.16-42", built.getOldVersion());
             assertEquals("3.36.16-100", built.getNewVersion());
+            assertTrue("agent from diff is used, got: " + built.getIdsString(), built.getIdsString().contains("agent-1"));
         } finally {
             server.stop(0);
         }
+    }
+
+    @Test
+    public void getCurrentVersionWithoutEnabledDiffReturnsEmpty() {
+        Task noDiff = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "demo 1.2.3", 1, null);
+        assertTrue(diffService.getCurrentVersion(noDiff).isEmpty());
+
+        Task disabled = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "demo 1.2.3", 1,
+                TaskDiff.builder().enabled(false).versionUrl("http://x").gitlabProjectId(1).build());
+        assertTrue(diffService.getCurrentVersion(disabled).isEmpty());
     }
 }

--- a/integration-test/src/test/java/io/pne/deploy/tests/VertxAndWebsocketTest.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/VertxAndWebsocketTest.java
@@ -41,7 +41,7 @@ public class VertxAndWebsocketTest {
         Task task = new Task(generateTaskId(), new TaskParameters(), Arrays.asList(
                 shell("test-host", "echo", "test123"),
                 shell("test-host", "echo", "test1234")
-        ), "test-task", 0);
+        ), "test-task", 0, null);
 
         List<RunAgentCommandResponse> responses = runAndCollect(9090, "test-host", 2,
                 app -> app.getDeployService().runTask(task));
@@ -55,7 +55,7 @@ public class VertxAndWebsocketTest {
         Task task = new Task(generateTaskId(), new TaskParameters(), singletonList(
                 new TaskCommand(agentByName("test-host"), new AgentCommand(
                         new AgentCommandParameters(), SHELL, "sh", Arrays.asList("-c", "exit 1")))
-        ), "failing-task", 0);
+        ), "failing-task", 0, null);
 
         try {
             runAndCollect(9091, "test-host", 1, app -> app.getDeployService().runTask(task));

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
@@ -48,7 +48,7 @@ public class LocalEnvironment implements AutoCloseable {
     private static final String ALIAS        = "deploy-demo";
     private static final String CALLBACK_URI = "/redmine/callback";
     // The line the pipeline looks for in the issue description (alias-line chars are restricted: no '/', ':', '=').
-    private static final String DEPLOY_LINE = "> deploy " + ALIAS;
+    private static final String DEPLOY_LINE = "> deploy " + ALIAS + " 1.2.3";
 
     private final int serverPort   = Ports.free();
     private final int redminePort  = Ports.free();
@@ -142,21 +142,22 @@ public class LocalEnvironment implements AutoCloseable {
 
             String oldVersionUrl = "http://127.0.0.1:" + gitlabPort + "/old-version";
             String yaml = ""
+                    + "diff:\n"
+                    + "  enabled: true\n"
+                    + "  versionUrl: " + oldVersionUrl + "\n"
+                    + "  gitlabProjectId: 42\n"
+                    + "  agent: agent-1\n"
                     + "commands:\n"
                     + "- agents: agent-1\n"
                     + "  name: echo\n"
                     + "  arguments:\n"
                     + "    - deployed\n"
-                    + "    - 1.2.3\n"
-                    + "    - " + oldVersionUrl + "\n"
-                    + "    - gitlab=42\n"
+                    + "    - $1\n"
                     + "- agents: agent-2\n"
                     + "  name: echo\n"
                     + "  arguments:\n"
                     + "    - deployed\n"
-                    + "    - 1.2.3\n"
-                    + "    - " + oldVersionUrl + "\n"
-                    + "    - gitlab=42\n";
+                    + "    - $1\n";
             Files.writeString(aliasesDir.resolve(ALIAS + ".yml"), yaml, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException("cannot write temp environment files", e);

--- a/server-api/pom.xml
+++ b/server-api/pom.xml
@@ -28,6 +28,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -37,7 +42,7 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
     </dependencies>
 
 </project>

--- a/server-api/src/main/java/io/pne/deploy/server/api/task/Task.java
+++ b/server-api/src/main/java/io/pne/deploy/server/api/task/Task.java
@@ -1,6 +1,7 @@
 package io.pne.deploy.server.api.task;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -10,17 +11,21 @@ public class Task {
 
     @Nonnull public final TaskId            id;
     @Nonnull public final List<TaskCommand>     commands;
-    @Nonnull public final TaskParameters    parameters;
+    @Nonnull public final TaskParameters parameters;
 
     @Nonnull public final String taskLine;
     public final int    issueId;
 
-    public Task(@Nonnull TaskId aId, @Nonnull TaskParameters aParameters, @Nonnull List<TaskCommand> aCommands, @Nonnull String aTaskLine, int aIssueId) {
+    @Nullable
+    public final TaskDiff diff;
+
+    public Task(@Nonnull TaskId aId, @Nonnull TaskParameters aParameters, @Nonnull List<TaskCommand> aCommands, @Nonnull String aTaskLine, int aIssueId, @Nullable TaskDiff aDiff) {
         id          = aId;
         commands    = aCommands;
         parameters  = aParameters;
         taskLine    = aTaskLine;
         issueId     = aIssueId;
+        diff        = aDiff;
     }
 
     @Override
@@ -29,6 +34,7 @@ public class Task {
                 "id=" + id +
                 ", commands=" + commands +
                 ", parameters=" + parameters +
+                ", diff=" + diff +
                 '}';
     }
 }

--- a/server-api/src/main/java/io/pne/deploy/server/api/task/TaskDiff.java
+++ b/server-api/src/main/java/io/pne/deploy/server/api/task/TaskDiff.java
@@ -1,0 +1,19 @@
+package io.pne.deploy.server.api.task;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Data
+@FieldDefaults(makeFinal = true, level = PRIVATE)
+@Builder
+public class TaskDiff {
+
+    boolean enabled;
+    String  versionUrl;
+    int     gitlabProjectId;
+    String  agent;
+
+}

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStoreTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/status/telegram/TelegramMessagesStoreTest.java
@@ -32,7 +32,7 @@ public class TelegramMessagesStoreTest {
         when(telegram.sendMessage(anyLong(), anyString(), any())).thenReturn(ROLLED_MSG);
 
         Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
-                Collections.emptyList(), "deploy something", 0);
+                Collections.emptyList(), "deploy something", 0, null);
         store.addTask(task, FIRST_MSG, "start");
 
         // push enough long lines to blow past TG_SAFE_MAX (4000)

--- a/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasDescription.java
+++ b/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasDescription.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public class AliasDescription {
     public List<AliasCommand> commands;
+    public AliasDiff          diff;
 }

--- a/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasDiff.java
+++ b/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasDiff.java
@@ -1,0 +1,9 @@
+package io.pne.deploy.server.service.impl.alias;
+
+/** Optional {@code diff:} block of an alias (mutable so SnakeYAML can populate it); mapped to TaskDiff. */
+public class AliasDiff {
+    public boolean enabled;
+    public String  versionUrl;
+    public int     gitlabProjectId;
+    public String  agent;
+}

--- a/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasParser.java
+++ b/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasParser.java
@@ -47,6 +47,12 @@ public class AliasParser {
             );
             commands.add(new TaskCommand(agentByName(command.agents), agentCommand));
         }
-        return new Task(TaskId.generateTaskId(), new TaskParameters(), commands, aText, aIssueId);
+        TaskDiff diff = description.diff == null ? null : TaskDiff.builder()
+                .enabled(description.diff.enabled)
+                .versionUrl(description.diff.versionUrl)
+                .gitlabProjectId(description.diff.gitlabProjectId)
+                .agent(description.diff.agent)
+                .build();
+        return new Task(TaskId.generateTaskId(), new TaskParameters(), commands, aText, aIssueId, diff);
     }
 }

--- a/server/src/test/java/io/pne/deploy/server/service/impl/DeployServiceImplTest.java
+++ b/server/src/test/java/io/pne/deploy/server/service/impl/DeployServiceImplTest.java
@@ -43,7 +43,7 @@ public class DeployServiceImplTest {
         service.runTask(new Task(generateTaskId(), new TaskParameters(), singletonList(
                 new TaskCommand(agentByName("localhost"), new AgentCommand(
                         new AgentCommandParameters(), SHELL, "echo", singletonList("test")
-                ))), "test-task", 0)
+                ))), "test-task", 0, null)
         );
 
         System.out.println("Waiting for a text message from command ...");


### PR DESCRIPTION
## What
The diff pipeline no longer guesses its inputs by scanning command arguments (`VERSION_LIKE`, `LINK_LIKE`, `gitlab=<id>`). It now reads an explicit `Task.diff` (`TaskDiff`) config: **if `task.diff != null && enabled`**, `versionUrl`, `gitlabProjectId` and the reporting `agent` come from it; otherwise no diff.

## Model
- `TaskDiff` (server-api): `enabled`, `versionUrl`, `gitlabProjectId` (renamed from `gitlabRepoId`, matches `DiffTask.gitlabProject`), `agent`. `Task` gained `@Nullable diff` (+ 6-arg ctor; lombok added to server-api).
- Alias layer (server): new mutable `AliasDiff` (so SnakeYAML can populate it) → `AliasDescription.diff` → `AliasParser` maps it to `TaskDiff` on the `Task`.

## Diff (client-redmine)
`DiffServiceImpl.getCurrentVersion` is now task-level: gate on `task.diff.isEnabled()`; `newVersion` = the first parameter of the task line (`"<alias> <version>"`, i.e. `$1`); `oldVersion` = fetched from `diff.versionUrl`; builds **one** `DiffTask` attributed to `diff.agent`. Removed the argument-scanning patterns/helpers. `processDiff` unchanged.

## Alias YAML format
```yaml
diff:
  enabled: true
  versionUrl: "http://.../version.txt?filter=version"
  gitlabProjectId: 114
  agent: dui-1
commands:
  - agents: dui-1
    name: ./bin/redeploy-sandbox-ui.sh
    arguments: [ $1, "http://.../version.txt?filter=version" ]   # url stays for the script's own CheckVersion
```
(`gitlab=…` removed from args; `versionUrl` lives in the `diff:` block for the diff.)

## Tests
- Rewrote the `getCurrentVersion` test to drive off `TaskDiff` (local HttpServer serves the old version; asserts one `DiffTask` with project 42, `oldVersion`, `newVersion` from the task line, and `agent-1` id), plus a no-diff/disabled → empty case.
- Updated `LocalEnvironment` (deploy line carries the version; demo alias uses a `diff:` block) — `FullEnvironmentTest` still sees the GitLab compare.
- Fixed all `new Task(...)` callers for the 6-arg ctor.
- `mvn -B -ntp verify` under JDK 21 → BUILD SUCCESS.

## Note
Aliases must add a `diff:` block to get a diff now — old aliases relying on `gitlab=`/URL args will no longer trigger one (by design).