### PR TITLE
feat(diff): read the current version through the agent via HttpURLConnection

### DIFF
--- a/agent-api/src/main/java/io/pne/deploy/agent/api/messages/AgentMessageType.java
+++ b/agent-api/src/main/java/io/pne/deploy/agent/api/messages/AgentMessageType.java
@@ -6,6 +6,8 @@ public enum AgentMessageType {
       RUN_COMMAND_REQUEST  (1, RunAgentCommandRequest.class)
     , RUN_COMMAND_RESPONSE (2, RunAgentCommandResponse.class)
     , RUN_COMMAND_LOG      (3, RunAgentCommandLog.class    )
+    , GET_VERSION_REQUEST  (4, GetVersionRequest.class     )
+    , GET_VERSION_RESPONSE (5, GetVersionResponse.class    )
     ;
 
     public final byte id;

--- a/agent-api/src/main/java/io/pne/deploy/agent/api/messages/GetVersionRequest.java
+++ b/agent-api/src/main/java/io/pne/deploy/agent/api/messages/GetVersionRequest.java
@@ -1,0 +1,18 @@
+package io.pne.deploy.agent.api.messages;
+
+/** Server -> agent: fetch {@code versionUrl} from where the agent (not the firewalled server) can reach it. */
+public class GetVersionRequest implements IAgentServerMessage {
+
+    public final String requestId;
+    public final String versionUrl;
+
+    public GetVersionRequest(String requestId, String versionUrl) {
+        this.requestId  = requestId;
+        this.versionUrl = versionUrl;
+    }
+
+    @Override
+    public String toString() {
+        return "GetVersionRequest{requestId='" + requestId + "', versionUrl='" + versionUrl + "'}";
+    }
+}

--- a/agent-api/src/main/java/io/pne/deploy/agent/api/messages/GetVersionResponse.java
+++ b/agent-api/src/main/java/io/pne/deploy/agent/api/messages/GetVersionResponse.java
@@ -1,0 +1,20 @@
+package io.pne.deploy.agent.api.messages;
+
+/** Agent -> server: the fetched version (or {@code error} when the agent couldn't read it). */
+public class GetVersionResponse implements IAgentClientMessage {
+
+    public final String requestId;
+    public final String version;
+    public final String error;
+
+    public GetVersionResponse(String requestId, String version, String error) {
+        this.requestId = requestId;
+        this.version   = version;
+        this.error     = error;
+    }
+
+    @Override
+    public String toString() {
+        return "GetVersionResponse{requestId='" + requestId + "', version='" + version + "', error='" + error + "'}";
+    }
+}

--- a/agent-websocket/src/main/java/io/pne/deploy/agent/websocket/WebSocketListenerImpl.java
+++ b/agent-websocket/src/main/java/io/pne/deploy/agent/websocket/WebSocketListenerImpl.java
@@ -8,8 +8,11 @@ import io.pne.deploy.agent.api.IAgentService;
 import io.pne.deploy.agent.api.exceptions.AgentCommandException;
 import io.pne.deploy.agent.api.messages.AgentMessageType;
 import io.pne.deploy.agent.api.messages.IAgentServerMessage;
+import io.pne.deploy.agent.api.messages.GetVersionRequest;
+import io.pne.deploy.agent.api.messages.GetVersionResponse;
 import io.pne.deploy.agent.api.messages.RunAgentCommandRequest;
 import io.pne.deploy.agent.api.messages.RunAgentCommandResponse;
+import io.pne.deploy.agent.commands.VersionFetcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +56,20 @@ public class WebSocketListenerImpl implements IWebSocketListener {
                 }
                 break;
 
+            case GET_VERSION_REQUEST:
+                GetVersionRequest versionRequest = (GetVersionRequest) message;
+                try {
+                    String fetchedVersion = VersionFetcher.fetch(versionRequest.versionUrl);
+                    LOG.info("GetVersion {} -> {}", versionRequest.versionUrl, fetchedVersion);
+                    queue.enqueue(new GetVersionResponse(versionRequest.requestId, fetchedVersion, null));
+                } catch (Exception e) {
+                    LOG.warn("Can't fetch version from {}", versionRequest.versionUrl, e);
+                    queue.enqueue(new GetVersionResponse(versionRequest.requestId, null, e.toString()));
+                }
+                break;
+
             default:
-                throw new IllegalStateException(type + " not supported");
+                LOG.warn("Unsupported message type {} — ignoring", type);
 
         }
     }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
@@ -10,15 +10,12 @@ import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
 import io.pne.deploy.client.redmine.remote.impl.RemoteGitlabServiceImpl;
 import io.pne.deploy.client.redmine.remote.impl.RemoteTelegramServiceImpl;
+import io.pne.deploy.server.api.IAgentVersionReader;
 import io.pne.deploy.server.api.task.Task;
 import io.pne.deploy.server.api.task.TaskDiff;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,21 +29,23 @@ public class DiffServiceImpl implements DiffService {
     private final IRemoteGitlabService gitlab;
     private final IRemoteTelegramService telegram;
     private final String redmineUrl;
+    private final IAgentVersionReader versionReader;
 
-    public DiffServiceImpl(IRemoteRedmineService aRedmine, IRedmineRemoteConfig aConfig) {
-        this(aRedmine, new RemoteGitlabServiceImpl(aConfig), new RemoteTelegramServiceImpl(aConfig), aConfig.url());
+    public DiffServiceImpl(IRemoteRedmineService aRedmine, IRedmineRemoteConfig aConfig, IAgentVersionReader aVersionReader) {
+        this(aRedmine, new RemoteGitlabServiceImpl(aConfig), new RemoteTelegramServiceImpl(aConfig), aConfig.url(), aVersionReader);
     }
 
-    public DiffServiceImpl(IRemoteRedmineService aRedmine, IRemoteTelegramService aTelegram, IRedmineRemoteConfig aConfig) {
-        this(aRedmine, new RemoteGitlabServiceImpl(aConfig), aTelegram, aConfig.url());
+    public DiffServiceImpl(IRemoteRedmineService aRedmine, IRemoteTelegramService aTelegram, IRedmineRemoteConfig aConfig, IAgentVersionReader aVersionReader) {
+        this(aRedmine, new RemoteGitlabServiceImpl(aConfig), aTelegram, aConfig.url(), aVersionReader);
     }
 
     public DiffServiceImpl(IRemoteRedmineService aRedmine, IRemoteGitlabService aGitlab,
-                           IRemoteTelegramService aTelegram, String aRedmineUrl) {
+                           IRemoteTelegramService aTelegram, String aRedmineUrl, IAgentVersionReader aVersionReader) {
         this.redmine = aRedmine;
         this.gitlab = aGitlab;
         this.telegram = aTelegram;
         this.redmineUrl = aRedmineUrl;
+        this.versionReader = aVersionReader;
     }
 
     public void processDiff(List<DiffTask> tasks, int issueId) {
@@ -91,23 +90,18 @@ public class DiffServiceImpl implements DiffService {
             LOG.info("Diff: skip '{}' — no version in the task line", task.taskLine);
             return new ArrayList<>();
         }
-        try {
-            String oldVersion = getUrlContent(diff.getVersionUrl());
-            if (oldVersion == null || oldVersion.isEmpty()) {
-                LOG.info("Diff: skip '{}' — old version is empty from {}", task.taskLine, diff.getVersionUrl());
-                return new ArrayList<>();
-            }
-            String[] agents = diff.getAgent() == null || diff.getAgent().isBlank()
-                    ? new String[0] : new String[]{diff.getAgent()};
-            LOG.info("Diff: '{}' — gitlabProjectId={}, {} -> {}, agent={}",
-                    task.taskLine, diff.getGitlabProjectId(), oldVersion, newVersion, diff.getAgent());
-            List<DiffTask> diffTasks = new ArrayList<>();
-            diffTasks.add(new DiffTask(agents, diff.getGitlabProjectId(), task.taskLine, oldVersion, newVersion));
-            return diffTasks;
-        } catch (Exception e) {
-            LOG.error("Diff: can't build diff task for '{}'", task.taskLine, e);
+        String oldVersion = versionReader.readVersion(diff.getAgent(), diff.getVersionUrl());
+        if (oldVersion == null || oldVersion.isEmpty()) {
+            LOG.info("Diff: skip '{}' — no old version via agent {} from {}", task.taskLine, diff.getAgent(), diff.getVersionUrl());
             return new ArrayList<>();
         }
+        String[] agents = diff.getAgent() == null || diff.getAgent().isBlank()
+                ? new String[0] : new String[]{diff.getAgent()};
+        LOG.info("Diff: '{}' — gitlabProjectId={}, {} -> {}, agent={}",
+                task.taskLine, diff.getGitlabProjectId(), oldVersion, newVersion, diff.getAgent());
+        List<DiffTask> diffTasks = new ArrayList<>();
+        diffTasks.add(new DiffTask(agents, diff.getGitlabProjectId(), task.taskLine, oldVersion, newVersion));
+        return diffTasks;
     }
 
     /** The deploy version is the first parameter of the task line ("&lt;alias&gt; &lt;version&gt; ..."). */
@@ -266,25 +260,4 @@ public class DiffServiceImpl implements DiffService {
         return null;
     }
 
-    private static String getUrlContent(String aUrl) throws IOException {
-        LOG.info("Loading {}", aUrl);
-        URL url = new URL(aUrl);
-        URLConnection con = url.openConnection();
-        con.setConnectTimeout(10_000);
-        con.setReadTimeout(10_000);
-        InputStream in = con.getInputStream();
-        if (in == null) {
-            throw new IllegalStateException("Input stream is null for " + url);
-        }
-        try {
-            Scanner scanner = new Scanner(in, "utf-8");
-            if (scanner.hasNextLine()) {
-                return scanner.nextLine();
-            } else {
-                throw new IllegalStateException("No content for url " + url);
-            }
-        } finally {
-            in.close();
-        }
-    }
 }

--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/RedmineIssuesProcessServiceImpl.java
@@ -10,6 +10,7 @@ import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
+import io.pne.deploy.server.api.IAgentVersionReader;
 import io.pne.deploy.server.api.IDeployService;
 import io.pne.deploy.server.api.exceptions.TaskException;
 import io.pne.deploy.server.api.task.Task;
@@ -42,10 +43,10 @@ public class RedmineIssuesProcessServiceImpl implements IRedmineIssuesProcessSer
     });
 
 
-    public RedmineIssuesProcessServiceImpl(IRemoteRedmineService redmine, IDeployService deployService, IRedmineRemoteConfig aConfig, IRemoteTelegramService telegram) {
+    public RedmineIssuesProcessServiceImpl(IRemoteRedmineService redmine, IDeployService deployService, IRedmineRemoteConfig aConfig, IRemoteTelegramService telegram, IAgentVersionReader aVersionReader) {
         this.redmine = redmine;
         this.deployService = deployService;
-        this.diffService = new DiffServiceImpl(redmine, telegram, aConfig);
+        this.diffService = new DiffServiceImpl(redmine, telegram, aConfig, aVersionReader);
         issueValidationScript = aConfig.issueValidationScript();
     }
 

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImplTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImplTest.java
@@ -6,6 +6,7 @@ import io.pne.deploy.client.redmine.process.data_model.DiffTask;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
 import io.pne.deploy.client.redmine.remote.impl.IRedmineRemoteConfig;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
+import io.pne.deploy.server.api.IAgentVersionReader;
 import org.junit.Test;
 
 import java.util.*;
@@ -18,7 +19,7 @@ public class DiffServiceImplTest {
 
     private final IRemoteRedmineService redmine = mock(IRemoteRedmineService.class);
     private final DiffServiceImpl diffService =
-            new DiffServiceImpl(redmine, getStartupParameters(IRedmineRemoteConfig.class));
+            new DiffServiceImpl(redmine, getStartupParameters(IRedmineRemoteConfig.class), mock(IAgentVersionReader.class));
 
     // --- aggregate ---
 

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
@@ -5,21 +5,18 @@ import io.pne.deploy.client.redmine.remote.IRemoteGitlabService;
 import io.pne.deploy.client.redmine.remote.IRemoteRedmineService;
 import io.pne.deploy.client.redmine.remote.IRemoteTelegramService;
 import io.pne.deploy.client.redmine.remote.model.RedmineIssue;
+import io.pne.deploy.server.api.IAgentVersionReader;
 import io.pne.deploy.server.api.task.Task;
 import io.pne.deploy.server.api.task.TaskDiff;
 import io.pne.deploy.server.api.task.TaskId;
 import io.pne.deploy.server.api.task.TaskParameters;
-import com.sun.net.httpserver.HttpServer;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -40,9 +37,10 @@ public class DiffServiceProcessDiffTest {
     private final IRemoteRedmineService  redmine  = mock(IRemoteRedmineService.class);
     private final IRemoteGitlabService   gitlab   = mock(IRemoteGitlabService.class);
     private final IRemoteTelegramService telegram = mock(IRemoteTelegramService.class);
+    private final IAgentVersionReader    reader   = mock(IAgentVersionReader.class);
 
     private final DiffServiceImpl diffService =
-            new DiffServiceImpl(redmine, gitlab, telegram, "https://redmine.example");
+            new DiffServiceImpl(redmine, gitlab, telegram, "https://redmine.example", reader);
 
     @Test
     public void processDiffPostsAggregatedCommentAndTelegramMessages() {
@@ -76,37 +74,27 @@ public class DiffServiceProcessDiffTest {
 
     /**
      * The diff is driven by {@code task.diff} (versionUrl / gitlabProjectId / agent), not by command arguments;
-     * newVersion is the first parameter of the task line. Old version is fetched from the diff's versionUrl.
+     * newVersion is the first parameter of the task line. The old version is fetched through the agent
+     * (the deploy-server can't reach the firewalled versionUrl), so the reader is mocked here.
      */
     @Test
-    public void getCurrentVersionUsesTaskDiff() throws Exception {
-        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext("/version", exchange -> {
-            byte[] body = "3.36.16-42\n".getBytes(UTF_8);
-            exchange.sendResponseHeaders(200, body.length);
-            try (OutputStream os = exchange.getResponseBody()) {
-                os.write(body);
-            }
-        });
-        server.start();
-        String versionUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/version";
-        try {
-            TaskDiff diff = TaskDiff.builder()
-                    .enabled(true).versionUrl(versionUrl).gitlabProjectId(42).agent("agent-1").build();
-            Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
-                    Collections.emptyList(), "demo 3.36.16-100", 168059, diff);
+    public void getCurrentVersionUsesTaskDiff() {
+        String versionUrl = "http://firewalled.example/version";
+        when(reader.readVersion("agent-1", versionUrl)).thenReturn("3.36.16-42");
 
-            List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
+        TaskDiff diff = TaskDiff.builder()
+                .enabled(true).versionUrl(versionUrl).gitlabProjectId(42).agent("agent-1").build();
+        Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "demo 3.36.16-100", 168059, diff);
 
-            assertEquals(1, diffTasks.size());
-            DiffTask built = diffTasks.get(0);
-            assertEquals(Integer.valueOf(42), built.getGitlabProject());
-            assertEquals("3.36.16-42", built.getOldVersion());
-            assertEquals("3.36.16-100", built.getNewVersion());
-            assertTrue("agent from diff is used, got: " + built.getIdsString(), built.getIdsString().contains("agent-1"));
-        } finally {
-            server.stop(0);
-        }
+        List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
+
+        assertEquals(1, diffTasks.size());
+        DiffTask built = diffTasks.get(0);
+        assertEquals(Integer.valueOf(42), built.getGitlabProject());
+        assertEquals("3.36.16-42", built.getOldVersion());
+        assertEquals("3.36.16-100", built.getNewVersion());
+        assertTrue("agent from diff is used, got: " + built.getIdsString(), built.getIdsString().contains("agent-1"));
     }
 
     @Test

--- a/commands/src/main/java/io/pne/deploy/agent/commands/CheckVersionCommand.java
+++ b/commands/src/main/java/io/pne/deploy/agent/commands/CheckVersionCommand.java
@@ -4,10 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.Scanner;
 import java.util.StringTokenizer;
 
 public class CheckVersionCommand {
@@ -66,21 +62,6 @@ public class CheckVersionCommand {
 
     private static String getUrlContent(String aUrl) throws IOException {
         LOG.info("Loading {}", aUrl);
-        URL url = new URL(aUrl);
-        URLConnection con = url.openConnection();
-        InputStream in = con.getInputStream();
-        if(in == null) {
-            throw new IllegalStateException("Input stream is null for " + url);
-        }
-        try {
-            Scanner scanner = new Scanner(in, "utf-8");
-            if(scanner.hasNextLine()) {
-                return scanner.nextLine();
-            } else {
-                throw new IllegalStateException("No content for url " + url);
-            }
-        } finally {
-            in.close();
-        }
+        return VersionFetcher.fetch(aUrl);
     }
 }

--- a/commands/src/main/java/io/pne/deploy/agent/commands/VersionFetcher.java
+++ b/commands/src/main/java/io/pne/deploy/agent/commands/VersionFetcher.java
@@ -1,0 +1,34 @@
+package io.pne.deploy.agent.commands;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Scanner;
+
+/**
+ * Reads the current application version from a URL the agent can reach (the deploy-server is often firewalled
+ * off from it). Returns the first non-empty line; throws on a connection/HTTP error.
+ */
+public final class VersionFetcher {
+
+    private VersionFetcher() {
+    }
+
+    public static String fetch(String aUrl) throws IOException {
+        URL url = new URL(aUrl);
+        URLConnection con = url.openConnection();
+        con.setConnectTimeout(10_000);
+        con.setReadTimeout(10_000);
+        try (InputStream in = con.getInputStream()) {
+            Scanner scanner = new Scanner(in, "UTF-8");
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (!line.isEmpty()) {
+                    return line;
+                }
+            }
+            throw new IllegalStateException("No content for url " + url);
+        }
+    }
+}

--- a/server-api/src/main/java/io/pne/deploy/server/api/IAgentVersionReader.java
+++ b/server-api/src/main/java/io/pne/deploy/server/api/IAgentVersionReader.java
@@ -1,0 +1,10 @@
+package io.pne.deploy.server.api;
+
+/**
+ * Reads the current application version from a URL that only the agent (not the firewalled deploy-server) can
+ * reach. Returns {@code null} when it can't be read.
+ */
+public interface IAgentVersionReader {
+
+    String readVersion(String aAgentId, String aVersionUrl);
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/AgentVersionReaderImpl.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/AgentVersionReaderImpl.java
@@ -1,0 +1,62 @@
+package io.pne.deploy.server.vertx;
+
+import com.google.gson.Gson;
+import io.pne.deploy.agent.api.messages.AgentMessageType;
+import io.pne.deploy.agent.api.messages.GetVersionRequest;
+import io.pne.deploy.agent.api.messages.GetVersionResponse;
+import io.pne.deploy.agent.api.messages.IAgentServerMessage;
+import io.pne.deploy.server.api.IAgentVersionReader;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ServerWebSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/** Asks {@code agentId} to fetch {@code versionUrl} itself (HttpURLConnection) and returns the version. */
+public class AgentVersionReaderImpl implements IAgentVersionReader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgentVersionReaderImpl.class);
+
+    private final AgentConnections connections;
+    private final Gson             gson;
+    private final VersionResponses versionResponses;
+
+    public AgentVersionReaderImpl(AgentConnections aConnections, Gson aGson, VersionResponses aVersionResponses) {
+        this.connections      = aConnections;
+        this.gson             = aGson;
+        this.versionResponses = aVersionResponses;
+    }
+
+    @Override
+    public String readVersion(String aAgentId, String aVersionUrl) {
+        if (aAgentId == null || aAgentId.isBlank() || aVersionUrl == null || aVersionUrl.isBlank()) {
+            LOG.warn("readVersion: blank agent '{}' or url '{}'", aAgentId, aVersionUrl);
+            return null;
+        }
+        String requestId = "getversion-" + UUID.randomUUID();
+        try {
+            ServerWebSocket socket = connections.getSocket(aAgentId);
+            LOG.info("Asking agent {} for the version at {} (request {})", aAgentId, aVersionUrl, requestId);
+            socket.writeBinaryMessage(frame(new GetVersionRequest(requestId, aVersionUrl)));
+            GetVersionResponse response = versionResponses.awaitForVersionResponse(requestId);
+            if (response.error != null) {
+                LOG.warn("Agent {} couldn't read version from {}: {}", aAgentId, aVersionUrl, response.error);
+                return null;
+            }
+            return response.version;
+        } catch (Exception e) {
+            LOG.warn("Can't read version via agent {} from {}", aAgentId, aVersionUrl, e);
+            return null;
+        }
+    }
+
+    private Buffer frame(IAgentServerMessage aMessage) {
+        Buffer buffer = Buffer.buffer();
+        buffer.appendByte((byte) 0x01);
+        buffer.appendByte(AgentMessageType.findByClass(aMessage.getClass()).id);
+        buffer.appendBytes(gson.toJson(aMessage).getBytes(StandardCharsets.UTF_8));
+        return buffer;
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerWebSocketFrameHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerWebSocketFrameHandler.java
@@ -3,6 +3,7 @@ package io.pne.deploy.server.vertx;
 import com.google.gson.Gson;
 import io.pne.deploy.agent.api.messages.AgentMessageType;
 import io.pne.deploy.agent.api.messages.IAgentClientMessage;
+import io.pne.deploy.agent.api.messages.GetVersionResponse;
 import io.pne.deploy.agent.api.messages.RunAgentCommandLog;
 import io.pne.deploy.agent.api.messages.RunAgentCommandResponse;
 import io.pne.deploy.server.IServerApplicationListener;
@@ -23,13 +24,15 @@ public class ServerWebSocketFrameHandler {
     private final Gson                       gson;
     private final IServerApplicationListener serverListener;
     private final CommandResponses           commandResponses;
+    private final VersionResponses           versionResponses;
     private final ITaskExecutionListener     listener;
 
 
-    public ServerWebSocketFrameHandler(IServerApplicationListener aServerListener, Gson aGson, CommandResponses aResponses, ITaskExecutionListener aListener) {
+    public ServerWebSocketFrameHandler(IServerApplicationListener aServerListener, Gson aGson, CommandResponses aResponses, VersionResponses aVersionResponses, ITaskExecutionListener aListener) {
         gson = aGson;
         serverListener = aServerListener;
         commandResponses = aResponses;
+        versionResponses = aVersionResponses;
         listener = aListener;
     }
 
@@ -61,6 +64,11 @@ public class ServerWebSocketFrameHandler {
                 RunAgentCommandLog logMessage = (RunAgentCommandLog) message;
                 LOG_AGENT.info("{} {}: {}", aAgentId, logMessage.commandId, logMessage.message);
                 listener.onCommandLog(logMessage);
+                break;
+
+            case GET_VERSION_RESPONSE:
+                GetVersionResponse versionResponse = (GetVersionResponse) message;
+                versionResponses.addResponse(versionResponse.requestId, versionResponse);
                 break;
 
             default:

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VersionResponses.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VersionResponses.java
@@ -1,0 +1,29 @@
+package io.pne.deploy.server.vertx;
+
+import io.pne.deploy.agent.api.messages.GetVersionResponse;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Correlates a {@link GetVersionResponse} coming back from an agent to the request that is waiting for it. */
+public class VersionResponses {
+
+    private static final int WAIT_TIMEOUT_SECONDS = 60;
+
+    private final Map<String, GetVersionResponse> map = new ConcurrentHashMap<>();
+
+    public GetVersionResponse awaitForVersionResponse(String aRequestId) throws InterruptedException {
+        for (int i = 0; i < WAIT_TIMEOUT_SECONDS; i++) {
+            GetVersionResponse response = map.remove(aRequestId);
+            if (response != null) {
+                return response;
+            }
+            Thread.sleep(1_000);
+        }
+        throw new IllegalStateException("No version response for " + aRequestId + " within " + WAIT_TIMEOUT_SECONDS + "s");
+    }
+
+    public void addResponse(String aRequestId, GetVersionResponse aResponse) {
+        map.put(aRequestId, aResponse);
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -86,7 +86,8 @@ public class VertxServerApplication {
     // for test only
     public VertxServerApplication(IServerApplicationListener serverListener, IVertxServerConfiguration aConfig, IRedmineRemoteConfig redmineConfig) {
         Gson                   gson         = new GsonBuilder().setPrettyPrinting().create();
-        CommandResponses       response     = new CommandResponses();
+        CommandResponses       response         = new CommandResponses();
+        VersionResponses       versionResponses = new VersionResponses();
         ITaskExecutionListener taskListener = new TaskExecutionListenerLogger();
 
         this.vertx = Vertx.vertx();
@@ -104,7 +105,7 @@ public class VertxServerApplication {
                 buildConfigReport(redmineConfig, aConfig, dashboardConfig), aConfig.getAliasesDir(),
                 dashboardConfig.path(), dashboardConfig.refreshMs(), "");
 
-        this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
+        this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, versionResponses, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
         this.serverListener = serverListener;
         this.telegramClient = null;
     }
@@ -114,6 +115,7 @@ public class VertxServerApplication {
 
         Gson                      gson              = new GsonBuilder().setPrettyPrinting().create();
         CommandResponses          response          = new CommandResponses();
+        VersionResponses          versionResponses  = new VersionResponses();
         ArrayBlockingQueue<Long>  pendingIssues     = new ArrayBlockingQueue<>(1000);
         IRedmineRemoteConfig      redmineConfig     = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
 
@@ -144,7 +146,8 @@ public class VertxServerApplication {
         // Ring buffer of recent agent command-output logs, written by the server listener and read by the dashboard.
         AgentLogBuffer agentLogBuffer = new AgentLogBuffer(200);
 
-        RedmineIssuesProcessServiceImpl redmineIssuesProcessService = new RedmineIssuesProcessServiceImpl(redmine, deployService, redmineConfig, diffTelegram);
+        AgentVersionReaderImpl versionReader = new AgentVersionReaderImpl(agentConnections, gson, versionResponses);
+        RedmineIssuesProcessServiceImpl redmineIssuesProcessService = new RedmineIssuesProcessServiceImpl(redmine, deployService, redmineConfig, diffTelegram, versionReader);
         VertxServerApplicationListener serverListener = new VertxServerApplicationListener(redmineIssuesProcessService, pendingIssues, agentLogBuffer);
 
         this.vertx          = Vertx.vertx();
@@ -160,7 +163,7 @@ public class VertxServerApplication {
                 buildConfigReport(redmineConfig, config, dashboardConfig), config.getAliasesDir(),
                 dashboardConfig.path(), dashboardConfig.refreshMs(), dashboardConfig.serverLogFile());
 
-        this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
+        this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, versionResponses, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
         this.serverListener = serverListener;
         this.telegramClient = telegramClient;
     }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
@@ -38,6 +38,7 @@ public class WebSocketVerticle extends AbstractVerticle {
             , AgentConnections aConnections
             , Gson aGson
             , CommandResponses aCommandResponses
+            , VersionResponses aVersionResponses
             , IDeployService   aDeploService
             , Executor         aCommandExecutor
             , IRedmineRemoteConfig aRedmineConfig
@@ -47,7 +48,7 @@ public class WebSocketVerticle extends AbstractVerticle {
             , Handler<HttpServerRequest> aMetricsHttpHandler
             , DashboardHttpHandler aDashboardHttpHandler
     ) {
-        this.serverWebSocketFrameHandler = new ServerWebSocketFrameHandler(aServerListener, aGson, aCommandResponses, aListener);
+        this.serverWebSocketFrameHandler = new ServerWebSocketFrameHandler(aServerListener, aGson, aCommandResponses, aVersionResponses, aListener);
         port = aPort;
         connections = aConnections;
         deployService = aDeploService;


### PR DESCRIPTION
## Why

The deploy-server computed the diff's *old* version by fetching `diff.versionUrl` **itself**, but a firewall blocks the server from reaching that URL — only the **agent** can. As a result the diff was silently skipped (empty old version) and no Redmine/Telegram notification was sent.

## What

Fetch the old version **through the agent**, which reads the URL in-process with `HttpURLConnection` (no `curl`, no subprocess):

- **New agent message** (`agent-api`): `GetVersionRequest` (server→agent, `requestId` + `versionUrl`) and `GetVersionResponse` (agent→server, `requestId` + `version` + `error`), registered in `AgentMessageType` as ids 4 and 5.
- **Agent** (`commands` + `agent-websocket`): extract the URL read into a reusable `VersionFetcher.fetch(url)` (`HttpURLConnection`, first non-empty line, 10s timeouts); `CheckVersionCommand` now delegates to it (no behavior change). `WebSocketListenerImpl` handles `GET_VERSION_REQUEST` by fetching and replying with `GetVersionResponse`; the `default` branch now logs-and-ignores unknown messages instead of throwing (so an unknown type can't drop the connection).
- **Server** (`server-vertx`): `VersionResponses` correlates the reply to the waiting request (mirrors `CommandResponses`); `AgentVersionReaderImpl` (implements the new `server-api` `IAgentVersionReader`) sends the request to `diff.agent` and awaits the version. Wired through `WebSocketVerticle` → `ServerWebSocketFrameHandler` and `VertxServerApplication`.
- **Diff** (`client-redmine`): `DiffServiceImpl.getCurrentVersion` now calls `versionReader.readVersion(diff.getAgent(), diff.getVersionUrl())` instead of its own HTTP `getUrlContent` (removed). `RedmineIssuesProcessServiceImpl` accepts and threads the reader through.

## Tests

- `DiffServiceProcessDiffTest#getCurrentVersionUsesTaskDiff` now injects a mocked `IAgentVersionReader` (no local `HttpServer`).
- The end-to-end `integration-test` exercises the real agent answering `GET_VERSION_REQUEST` and fetching the version over `HttpURLConnection`.
- `mvn -B -ntp verify` green under JDK 21.

## Deploy note

Protocol addition — **redeploy the agents to 1.0-14+** so they understand the version request.