### PR TITLE
feat(dashboard): agent details screen with agent-reported version and heap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           cache: maven
 
       - name: Build fat jars
-        run: mvn -B -ntp package
+        run: mvn -B -ntp package -Ddeploy.agent.version=${GITHUB_REF_NAME}
 
       - name: Stage release artifacts
         run: |

--- a/agent-api/src/main/java/io/pne/deploy/agent/api/messages/AgentInfo.java
+++ b/agent-api/src/main/java/io/pne/deploy/agent/api/messages/AgentInfo.java
@@ -1,0 +1,20 @@
+package io.pne.deploy.agent.api.messages;
+
+/** Agent -> server: system info the agent pushes right after each connect (version + JVM heap). */
+public class AgentInfo implements IAgentClientMessage {
+
+    public final String version;
+    public final long   heapUsed;
+    public final long   heapMax;
+
+    public AgentInfo(String version, long heapUsed, long heapMax) {
+        this.version  = version;
+        this.heapUsed = heapUsed;
+        this.heapMax  = heapMax;
+    }
+
+    @Override
+    public String toString() {
+        return "AgentInfo{version='" + version + "', heapUsed=" + heapUsed + ", heapMax=" + heapMax + "}";
+    }
+}

--- a/agent-api/src/main/java/io/pne/deploy/agent/api/messages/AgentMessageType.java
+++ b/agent-api/src/main/java/io/pne/deploy/agent/api/messages/AgentMessageType.java
@@ -8,6 +8,7 @@ public enum AgentMessageType {
     , RUN_COMMAND_LOG      (3, RunAgentCommandLog.class    )
     , GET_VERSION_REQUEST  (4, GetVersionRequest.class     )
     , GET_VERSION_RESPONSE (5, GetVersionResponse.class    )
+    , AGENT_INFO           (6, AgentInfo.class             )
     ;
 
     public final byte id;

--- a/agent-websocket/pom.xml
+++ b/agent-websocket/pom.xml
@@ -86,6 +86,13 @@
     </dependencies>
 
     <build>
+        <resources>
+            <!-- Filter agent-version.properties so ${deploy.agent.version} is baked in at build time. -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/agent-websocket/src/main/java/io/pne/deploy/agent/websocket/AgentVersion.java
+++ b/agent-websocket/src/main/java/io/pne/deploy/agent/websocket/AgentVersion.java
@@ -1,0 +1,36 @@
+package io.pne.deploy.agent.websocket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/** The agent's own build version, baked into {@code agent-version.properties} at build time (from the git tag). */
+public final class AgentVersion {
+
+    private static final Logger LOG     = LoggerFactory.getLogger(AgentVersion.class);
+    private static final String VERSION = load();
+
+    private AgentVersion() {
+    }
+
+    public static String get() {
+        return VERSION;
+    }
+
+    private static String load() {
+        try (InputStream in = AgentVersion.class.getResourceAsStream("/agent-version.properties")) {
+            if (in == null) {
+                LOG.warn("agent-version.properties not found on the classpath");
+                return "";
+            }
+            Properties props = new Properties();
+            props.load(in);
+            return props.getProperty("version", "").trim();
+        } catch (Exception e) {
+            LOG.warn("Can't read the agent version", e);
+            return "";
+        }
+    }
+}

--- a/agent-websocket/src/main/java/io/pne/deploy/agent/websocket/WebSocketAgentApplication.java
+++ b/agent-websocket/src/main/java/io/pne/deploy/agent/websocket/WebSocketAgentApplication.java
@@ -8,6 +8,7 @@ import com.payneteasy.websocket.WebSocketHandshakeRequest;
 import com.payneteasy.websocket.WebSocketSession;
 import io.pne.deploy.agent.api.IAgentChannelService;
 import io.pne.deploy.agent.api.IAgentService;
+import io.pne.deploy.agent.api.messages.AgentInfo;
 import io.pne.deploy.agent.api.messages.RunAgentCommandLog;
 import io.pne.deploy.agent.service.IAgentApplicationListener;
 import io.pne.deploy.agent.service.IAgentStartupParameters;
@@ -62,6 +63,7 @@ public class WebSocketAgentApplication {
         while(!currentThread().isInterrupted()) {
             try {
                 session = connectToServer();
+                queue.enqueue(buildAgentInfo());
                 agentListener.didConnected();
                 try {
                     session.startAndWait(webSocketListener);
@@ -100,6 +102,13 @@ public class WebSocketAgentApplication {
                 LOG.error("Could not close session", e);
             }
         }
+    }
+
+    /** Snapshot pushed to the server right after connecting: baked version + current JVM heap. */
+    private static AgentInfo buildAgentInfo() {
+        Runtime runtime = getRuntime();
+        long    heapUsed = runtime.totalMemory() - runtime.freeMemory();
+        return new AgentInfo(AgentVersion.get(), heapUsed, runtime.maxMemory());
     }
 
     private WebSocketSession connectToServer() throws IOException {

--- a/agent-websocket/src/main/resources/agent-version.properties
+++ b/agent-websocket/src/main/resources/agent-version.properties
@@ -1,0 +1,1 @@
+version=${deploy.agent.version}

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
         <vertx.version>   4.5.11 </vertx.version>
         <slf4j.version>   2.0.16 </slf4j.version>
 
+        <!-- Agent version reported to the dashboard; baked at build time (release.yml passes the git tag). -->
+        <deploy.agent.version>${project.version}</deploy.agent.version>
+
     </properties>
 
     <scm>

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/AgentRegistry.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/AgentRegistry.java
@@ -1,0 +1,100 @@
+package io.pne.deploy.server.vertx;
+
+import io.pne.deploy.agent.api.messages.AgentInfo;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Per-agent details for the dashboard "Agents" screen: IP + connect time + status are derived server-side, while
+ * version + heap are pushed by the agent ({@link AgentInfo}) right after each connect. Disconnected agents are kept
+ * (with a last-seen time) so the screen can show them as {@code DISCONNECTED}. In-memory only (not persisted).
+ */
+public class AgentRegistry {
+
+    public enum Status { CONNECTED, DISCONNECTED }
+
+    /** Immutable snapshot of one agent, for rendering. */
+    public static final class AgentRecord {
+        public final String agentId;
+        public final String ip;
+        public final long   connectedAtMs;
+        public final long   lastSeenMs;
+        public final Status status;
+        public final String version;
+        public final Long   heapUsed;
+        public final Long   heapMax;
+
+        public AgentRecord(String aAgentId, String aIp, long aConnectedAtMs, long aLastSeenMs, Status aStatus,
+                           String aVersion, Long aHeapUsed, Long aHeapMax) {
+            agentId       = aAgentId;
+            ip            = aIp;
+            connectedAtMs = aConnectedAtMs;
+            lastSeenMs    = aLastSeenMs;
+            status        = aStatus;
+            version       = aVersion;
+            heapUsed      = aHeapUsed;
+            heapMax       = aHeapMax;
+        }
+    }
+
+    private static final class Mutable {
+        String agentId;
+        String ip;
+        long   connectedAtMs;
+        long   lastSeenMs;
+        Status status;
+        String version;
+        Long   heapUsed;
+        Long   heapMax;
+    }
+
+    private final Map<String, Mutable> map = new HashMap<>();
+
+    public synchronized void onConnect(String aAgentId, String aIp) {
+        long now = System.currentTimeMillis();
+        Mutable m = map.computeIfAbsent(aAgentId, id -> new Mutable());
+        m.agentId       = aAgentId;
+        m.ip            = aIp;
+        m.connectedAtMs = now;
+        m.lastSeenMs    = now;
+        m.status        = Status.CONNECTED;
+        // version/heap are kept from a previous connect until the fresh AgentInfo frame arrives (avoids a flicker).
+    }
+
+    public synchronized void onInfo(String aAgentId, AgentInfo aInfo) {
+        Mutable m = map.computeIfAbsent(aAgentId, id -> new Mutable());
+        m.agentId    = aAgentId;
+        m.version    = aInfo.version;
+        m.heapUsed   = aInfo.heapUsed;
+        m.heapMax    = aInfo.heapMax;
+        m.lastSeenMs = System.currentTimeMillis();
+        if (m.status == null) {
+            m.status = Status.CONNECTED;
+        }
+    }
+
+    public synchronized void onDisconnect(String aAgentId) {
+        Mutable m = map.get(aAgentId);
+        if (m != null) {
+            m.status     = Status.DISCONNECTED;
+            m.lastSeenMs = System.currentTimeMillis();
+        }
+    }
+
+    /** Connected agents first, then by id. */
+    public synchronized List<AgentRecord> snapshot() {
+        List<AgentRecord> list = new ArrayList<>(map.size());
+        for (Mutable m : map.values()) {
+            list.add(new AgentRecord(m.agentId, m.ip, m.connectedAtMs, m.lastSeenMs, m.status,
+                    m.version, m.heapUsed, m.heapMax));
+        }
+        list.sort(Comparator
+                .comparingInt((AgentRecord r) -> r.status == Status.CONNECTED ? 0 : 1)
+                .thenComparing(r -> r.agentId == null ? "" : r.agentId));
+        return list;
+    }
+}

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerWebSocketFrameHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/ServerWebSocketFrameHandler.java
@@ -1,6 +1,7 @@
 package io.pne.deploy.server.vertx;
 
 import com.google.gson.Gson;
+import io.pne.deploy.agent.api.messages.AgentInfo;
 import io.pne.deploy.agent.api.messages.AgentMessageType;
 import io.pne.deploy.agent.api.messages.IAgentClientMessage;
 import io.pne.deploy.agent.api.messages.GetVersionResponse;
@@ -25,14 +26,16 @@ public class ServerWebSocketFrameHandler {
     private final IServerApplicationListener serverListener;
     private final CommandResponses           commandResponses;
     private final VersionResponses           versionResponses;
+    private final AgentRegistry              agentRegistry;
     private final ITaskExecutionListener     listener;
 
 
-    public ServerWebSocketFrameHandler(IServerApplicationListener aServerListener, Gson aGson, CommandResponses aResponses, VersionResponses aVersionResponses, ITaskExecutionListener aListener) {
+    public ServerWebSocketFrameHandler(IServerApplicationListener aServerListener, Gson aGson, CommandResponses aResponses, VersionResponses aVersionResponses, AgentRegistry aAgentRegistry, ITaskExecutionListener aListener) {
         gson = aGson;
         serverListener = aServerListener;
         commandResponses = aResponses;
         versionResponses = aVersionResponses;
+        agentRegistry = aAgentRegistry;
         listener = aListener;
     }
 
@@ -69,6 +72,10 @@ public class ServerWebSocketFrameHandler {
             case GET_VERSION_RESPONSE:
                 GetVersionResponse versionResponse = (GetVersionResponse) message;
                 versionResponses.addResponse(versionResponse.requestId, versionResponse);
+                break;
+
+            case AGENT_INFO:
+                agentRegistry.onInfo(aAgentId, (AgentInfo) message);
                 break;
 
             default:

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/VertxServerApplication.java
@@ -88,6 +88,7 @@ public class VertxServerApplication {
         Gson                   gson         = new GsonBuilder().setPrettyPrinting().create();
         CommandResponses       response         = new CommandResponses();
         VersionResponses       versionResponses = new VersionResponses();
+        AgentRegistry          agentRegistry    = new AgentRegistry();
         ITaskExecutionListener taskListener = new TaskExecutionListenerLogger();
 
         this.vertx = Vertx.vertx();
@@ -100,12 +101,12 @@ public class VertxServerApplication {
         StatusHttpHandler    statusHttpHandler    = new StatusHttpHandler(agentConnections, pendingIssues);
         IDashboardConfig     dashboardConfig      = StartupParametersFactory.getStartupParameters(IDashboardConfig.class);
         DashboardHttpHandler dashboardHttpHandler = new DashboardHttpHandler(
-                this.vertx, agentConnections, pendingIssues, new LinkedHashMap<>(), statusHttpHandler::getLatestTaskStatus,
+                this.vertx, agentConnections, agentRegistry, pendingIssues, new LinkedHashMap<>(), statusHttpHandler::getLatestTaskStatus,
                 null, new AgentLogBuffer(200),
                 buildConfigReport(redmineConfig, aConfig, dashboardConfig), aConfig.getAliasesDir(),
                 dashboardConfig.path(), dashboardConfig.refreshMs(), "");
 
-        this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, versionResponses, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
+        this.verticle       = new WebSocketVerticle(aConfig.getPort(), serverListener, agentConnections, gson, response, versionResponses, agentRegistry, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, event -> {}, dashboardHttpHandler);
         this.serverListener = serverListener;
         this.telegramClient = null;
     }
@@ -116,6 +117,7 @@ public class VertxServerApplication {
         Gson                      gson              = new GsonBuilder().setPrettyPrinting().create();
         CommandResponses          response          = new CommandResponses();
         VersionResponses          versionResponses  = new VersionResponses();
+        AgentRegistry             agentRegistry     = new AgentRegistry();
         ArrayBlockingQueue<Long>  pendingIssues     = new ArrayBlockingQueue<>(1000);
         IRedmineRemoteConfig      redmineConfig     = StartupParametersFactory.getStartupParameters(IRedmineRemoteConfig.class);
 
@@ -158,12 +160,12 @@ public class VertxServerApplication {
         dashboardQueues.put("redmine",  redmine.getSpool());
         IDashboardConfig dashboardConfig = StartupParametersFactory.getStartupParameters(IDashboardConfig.class);
         DashboardHttpHandler dashboardHttpHandler = new DashboardHttpHandler(
-                this.vertx, agentConnections, pendingIssues, dashboardQueues, statusHttpHandler::getLatestTaskStatus,
+                this.vertx, agentConnections, agentRegistry, pendingIssues, dashboardQueues, statusHttpHandler::getLatestTaskStatus,
                 metrics, agentLogBuffer,
                 buildConfigReport(redmineConfig, config, dashboardConfig), config.getAliasesDir(),
                 dashboardConfig.path(), dashboardConfig.refreshMs(), dashboardConfig.serverLogFile());
 
-        this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, versionResponses, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
+        this.verticle       = new WebSocketVerticle(config.getPort(), serverListener, agentConnections, gson, response, versionResponses, agentRegistry, deployService, Executors.newSingleThreadExecutor(), redmineConfig, pendingIssues, taskListener, statusHttpHandler, metricsHttpHandler, dashboardHttpHandler);
         this.serverListener = serverListener;
         this.telegramClient = telegramClient;
     }

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/WebSocketVerticle.java
@@ -13,6 +13,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.net.SocketAddress;
 
 import java.util.Collection;
 import java.util.concurrent.Executor;
@@ -23,6 +25,7 @@ public class WebSocketVerticle extends AbstractVerticle {
 
     private final ServerWebSocketFrameHandler serverWebSocketFrameHandler;
     private final AgentConnections            connections;
+    private final AgentRegistry               agentRegistry;
     private final int                         port;
     private       HttpServer                  httpServer;
     private final IDeployService              deployService;
@@ -39,6 +42,7 @@ public class WebSocketVerticle extends AbstractVerticle {
             , Gson aGson
             , CommandResponses aCommandResponses
             , VersionResponses aVersionResponses
+            , AgentRegistry    aAgentRegistry
             , IDeployService   aDeploService
             , Executor         aCommandExecutor
             , IRedmineRemoteConfig aRedmineConfig
@@ -48,9 +52,10 @@ public class WebSocketVerticle extends AbstractVerticle {
             , Handler<HttpServerRequest> aMetricsHttpHandler
             , DashboardHttpHandler aDashboardHttpHandler
     ) {
-        this.serverWebSocketFrameHandler = new ServerWebSocketFrameHandler(aServerListener, aGson, aCommandResponses, aVersionResponses, aListener);
+        this.serverWebSocketFrameHandler = new ServerWebSocketFrameHandler(aServerListener, aGson, aCommandResponses, aVersionResponses, aAgentRegistry, aListener);
         port = aPort;
         connections = aConnections;
+        agentRegistry = aAgentRegistry;
         deployService = aDeploService;
         commandExecutor = aCommandExecutor;
         redmineConfig = aRedmineConfig;
@@ -75,10 +80,12 @@ public class WebSocketVerticle extends AbstractVerticle {
                     connections.addAgent(aSocket);
 
                     String agentId = connections.getAgentId(aSocket);
+                    agentRegistry.onConnect(agentId, ipOf(aSocket));
                     aSocket.frameHandler(frame -> serverWebSocketFrameHandler.onFrame(agentId, frame));
 
                     aSocket.closeHandler(aVoid -> {
                         connections.removeAgent(aSocket);
+                        agentRegistry.onDisconnect(agentId);
                         LOG.debug("CLOSED");
                     });
 
@@ -108,6 +115,11 @@ public class WebSocketVerticle extends AbstractVerticle {
                         aStartFuture.complete();
                     }
                 });
+    }
+
+    private static String ipOf(ServerWebSocket aSocket) {
+        SocketAddress address = aSocket.remoteAddress();
+        return address == null ? null : address.host();
     }
 
     @Override

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardHttpHandler.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
 import io.pne.deploy.server.service.impl.alias.AliasDescription;
 import io.pne.deploy.server.vertx.AgentConnections;
+import io.pne.deploy.server.vertx.AgentRegistry;
 import io.pne.deploy.server.vertx.status.model.TaskStatus;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -52,6 +53,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
 
     private final Vertx                        vertx;
     private final AgentConnections             agents;
+    private final AgentRegistry                agentRegistry;
     private final Collection<Long>             pendingIssues;
     private final Map<String, PersistentSpool> queues;
     private final Supplier<TaskStatus>         taskStatusSupplier;
@@ -81,6 +83,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     public DashboardHttpHandler(
             Vertx aVertx
             , AgentConnections aAgents
+            , AgentRegistry aAgentRegistry
             , Collection<Long> aPendingIssues
             , Map<String, PersistentSpool> aQueues
             , Supplier<TaskStatus> aTaskStatusSupplier
@@ -94,6 +97,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
     ) {
         this.vertx              = aVertx;
         this.agents             = aAgents;
+        this.agentRegistry      = aAgentRegistry;
         this.pendingIssues      = aPendingIssues;
         this.queues             = aQueues;
         this.taskStatusSupplier = aTaskStatusSupplier;
@@ -360,6 +364,7 @@ public class DashboardHttpHandler implements Handler<HttpServerRequest> {
             writeEvent(aResponse, "service", DashboardView.service(
                     ManagementFactory.getRuntimeMXBean().getUptime(), heapUsed, runtime.maxMemory(), agentSnapshot.size()));
             writeEvent(aResponse, "agents", DashboardView.agents(agentSnapshot));
+            writeEvent(aResponse, "agentsDetail", DashboardView.agentDetails(agentRegistry.snapshot(), System.currentTimeMillis()));
             writeEvent(aResponse, "status", DashboardView.status(taskStatusSupplier.get(), redmineBaseUrl));
             writeEvent(aResponse, "issues", DashboardView.issues(issueSnapshot));
             writeEvent(aResponse, "delivery", DashboardView.delivery(queues, latencySnapshot()));

--- a/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
+++ b/server-vertx/src/main/java/io/pne/deploy/server/vertx/dashboard/DashboardView.java
@@ -1,6 +1,7 @@
 package io.pne.deploy.server.vertx.dashboard;
 
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+import io.pne.deploy.server.vertx.AgentRegistry;
 import io.pne.deploy.server.service.impl.alias.AliasCommand;
 import io.pne.deploy.server.service.impl.alias.AliasDescription;
 import io.pne.deploy.server.vertx.status.model.TaskState;
@@ -40,6 +41,44 @@ public final class DashboardView {
             sb.append("</div>");
         }
         return sb.toString();
+    }
+
+    /**
+     * Per-agent details table (name, ip, uptime, heap, version, status). IP/uptime/status are server-derived;
+     * version and heap are pushed by the agent. {@code aNowMs} computes the connection uptime. Missing data is
+     * rendered as an empty ({@code &mdash;}) cell.
+     */
+    public static String agentDetails(List<AgentRegistry.AgentRecord> aAgents, long aNowMs) {
+        if (aAgents == null || aAgents.isEmpty()) {
+            return "<p class=\"muted\">no agents</p>";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div class=\"delivery-wrap\"><table class=\"delivery agents-table\"><thead><tr>")
+          .append("<th class=\"l\">name</th><th class=\"l\">ip</th><th>uptime</th><th>heap</th>")
+          .append("<th class=\"l\">version</th><th>status</th>")
+          .append("</tr></thead><tbody>");
+        for (AgentRegistry.AgentRecord agent : aAgents) {
+            boolean connected  = agent.status == AgentRegistry.Status.CONNECTED;
+            String  uptime     = connected ? formatDuration(Math.max(0, aNowMs - agent.connectedAtMs)) : "&mdash;";
+            String  heap       = agent.heapUsed != null && agent.heapMax != null
+                    ? formatBytes(agent.heapUsed) + " / " + formatBytes(agent.heapMax) : "&mdash;";
+            String  badgeClass = connected ? "ok" : "bad";
+            String  badgeText  = connected ? "connected" : "disconnected";
+            sb.append("<tr>")
+              .append("<td class=\"l\">").append(cell(agent.agentId)).append("</td>")
+              .append("<td class=\"l\">").append(cell(agent.ip)).append("</td>")
+              .append("<td>").append(uptime).append("</td>")
+              .append("<td>").append(heap).append("</td>")
+              .append("<td class=\"l\">").append(cell(agent.version)).append("</td>")
+              .append("<td><span class=\"badge ").append(badgeClass).append("\">").append(badgeText).append("</span></td>")
+              .append("</tr>");
+        }
+        sb.append("</tbody></table></div>");
+        return sb.toString();
+    }
+
+    private static String cell(String aValue) {
+        return aValue == null || aValue.isBlank() ? "&mdash;" : esc(aValue);
     }
 
     /** The last task pushed by the execution listener (nullable). {@code aRedmineBaseUrl} links the issue id. */

--- a/server-vertx/src/main/resources/dashboard/index.html
+++ b/server-vertx/src/main/resources/dashboard/index.html
@@ -284,6 +284,7 @@
     <div id="sse-status" class="banner" hidden>&#9888; Not connected to backend (SSE) &mdash; retrying&hellip;</div>
     <nav class="tabs">
         <button class="tab active" data-screen="live">Live</button>
+        <button class="tab" data-screen="agents">Agents</button>
         <button class="tab" data-screen="config">Config</button>
         <button class="tab" data-screen="aliases">Aliases</button>
         <button class="tab" data-screen="log">Log</button>
@@ -319,6 +320,13 @@
         <section class="card flush logs-card">
             <div class="card-head logs-head"><span>Agent logs</span><span class="streaming"><span class="dot"></span>streaming</span></div>
             <div class="logs-body" sse-swap="logs"><span class="muted" style="display:block; padding:12px 16px">connecting&hellip;</span></div>
+        </section>
+    </section>
+
+    <section id="screen-agents" class="screen" hidden>
+        <section class="card flush agents-detail-card">
+            <div class="card-head">Agents</div>
+            <div class="agents-detail-body" sse-swap="agentsDetail"><span class="muted" style="display:block; padding:12px 16px">connecting&hellip;</span></div>
         </section>
     </section>
 
@@ -387,7 +395,7 @@
 
         (function () {
             var tabs    = document.querySelectorAll('.tab');
-            var screens = { live: 'screen-live', config: 'screen-config', aliases: 'screen-aliases', log: 'screen-log' };
+            var screens = { live: 'screen-live', agents: 'screen-agents', config: 'screen-config', aliases: 'screen-aliases', log: 'screen-log' };
             tabs.forEach(function (tab) {
                 tab.addEventListener('click', function () {
                     if (!tab.getAttribute('data-screen')) { return; }

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/AgentRegistryTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/AgentRegistryTest.java
@@ -1,0 +1,103 @@
+package io.pne.deploy.server.vertx;
+
+import io.pne.deploy.agent.api.messages.AgentInfo;
+import io.pne.deploy.server.vertx.AgentRegistry.AgentRecord;
+import io.pne.deploy.server.vertx.AgentRegistry.Status;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class AgentRegistryTest {
+
+    @Test
+    public void onConnectAddsConnectedRecordWithIp() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onConnect("agent-1", "10.0.0.1");
+
+        List<AgentRecord> snapshot = registry.snapshot();
+        assertEquals(1, snapshot.size());
+        AgentRecord record = snapshot.get(0);
+        assertEquals("agent-1", record.agentId);
+        assertEquals("10.0.0.1", record.ip);
+        assertEquals(Status.CONNECTED, record.status);
+        assertNull(record.version);
+        assertNull(record.heapUsed);
+    }
+
+    @Test
+    public void onInfoAttachesVersionAndHeap() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onConnect("agent-1", "10.0.0.1");
+        registry.onInfo("agent-1", new AgentInfo("1.0-15", 111L, 222L));
+
+        AgentRecord record = registry.snapshot().get(0);
+        assertEquals("1.0-15", record.version);
+        assertEquals(Long.valueOf(111L), record.heapUsed);
+        assertEquals(Long.valueOf(222L), record.heapMax);
+        assertEquals(Status.CONNECTED, record.status);
+    }
+
+    @Test
+    public void onDisconnectKeepsRowAndMarksDisconnected() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onConnect("agent-1", "10.0.0.1");
+        registry.onInfo("agent-1", new AgentInfo("1.0-15", 1L, 2L));
+        registry.onDisconnect("agent-1");
+
+        List<AgentRecord> snapshot = registry.snapshot();
+        assertEquals(1, snapshot.size());
+        AgentRecord record = snapshot.get(0);
+        assertEquals(Status.DISCONNECTED, record.status);
+        assertEquals("1.0-15", record.version); // pushed info is retained after disconnect
+    }
+
+    @Test
+    public void reconnectFlipsBackToConnectedAndUpdatesIp() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onConnect("agent-1", "10.0.0.1");
+        registry.onDisconnect("agent-1");
+        registry.onConnect("agent-1", "10.0.0.2");
+
+        List<AgentRecord> snapshot = registry.snapshot();
+        assertEquals(1, snapshot.size());
+        assertEquals(Status.CONNECTED, snapshot.get(0).status);
+        assertEquals("10.0.0.2", snapshot.get(0).ip);
+    }
+
+    @Test
+    public void snapshotOrdersConnectedFirstThenById() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onConnect("zeta", "1.1.1.1");
+        registry.onConnect("alpha", "1.1.1.2");
+        registry.onConnect("beta", "1.1.1.3");
+        registry.onDisconnect("beta");
+
+        List<AgentRecord> snapshot = registry.snapshot();
+        assertEquals(3, snapshot.size());
+        assertEquals("alpha", snapshot.get(0).agentId); // connected, alphabetical
+        assertEquals("zeta", snapshot.get(1).agentId);
+        assertEquals("beta", snapshot.get(2).agentId);  // disconnected last
+        assertEquals(Status.DISCONNECTED, snapshot.get(2).status);
+    }
+
+    @Test
+    public void onDisconnectUnknownAgentIsNoOp() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onDisconnect("ghost");
+        assertTrue(registry.snapshot().isEmpty());
+    }
+
+    @Test
+    public void onInfoBeforeConnectDefaultsToConnected() {
+        AgentRegistry registry = new AgentRegistry();
+        registry.onInfo("agent-1", new AgentInfo("1.0-15", 1L, 2L));
+
+        AgentRecord record = registry.snapshot().get(0);
+        assertEquals(Status.CONNECTED, record.status);
+        assertEquals("1.0-15", record.version);
+    }
+}

--- a/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
+++ b/server-vertx/src/test/java/io/pne/deploy/server/vertx/dashboard/DashboardViewTest.java
@@ -1,6 +1,7 @@
 package io.pne.deploy.server.vertx.dashboard;
 
 import io.pne.deploy.client.redmine.remote.queue.PersistentSpool;
+import io.pne.deploy.server.vertx.AgentRegistry;
 import io.pne.deploy.server.service.impl.alias.AliasCommand;
 import io.pne.deploy.server.service.impl.alias.AliasDescription;
 import io.pne.deploy.server.vertx.status.model.TaskState;
@@ -51,6 +52,48 @@ public class DashboardViewTest {
     public void agentsEmptyShowsPlaceholder() {
         String html = DashboardView.agents(emptySet());
         assertTrue(html, html.contains("no agents connected"));
+    }
+
+    @Test
+    public void agentDetailsRendersAllFieldsForConnectedAgent() {
+        long connectedAt = 1_000L;
+        long now = connectedAt + 65_000L; // 1m 5s uptime
+        AgentRegistry.AgentRecord record = new AgentRegistry.AgentRecord(
+                "host-a", "10.0.0.5", connectedAt, now, AgentRegistry.Status.CONNECTED,
+                "1.0-15", 5L * 1024 * 1024, 10L * 1024 * 1024);
+        String html = DashboardView.agentDetails(List.of(record), now);
+        assertTrue(html, html.contains("host-a"));
+        assertTrue(html, html.contains("10.0.0.5"));
+        assertTrue(html, html.contains("1m 5s"));
+        assertTrue(html, html.contains("5.0 MiB / 10.0 MiB"));
+        assertTrue(html, html.contains("1.0-15"));
+        assertTrue(html, html.contains("badge ok"));
+        assertTrue(html, html.contains("connected"));
+    }
+
+    @Test
+    public void agentDetailsEmptyCellsAndDisconnectedBadgeForMissingData() {
+        AgentRegistry.AgentRecord record = new AgentRegistry.AgentRecord(
+                "host-b", null, 0, 5_000L, AgentRegistry.Status.DISCONNECTED, null, null, null);
+        String html = DashboardView.agentDetails(List.of(record), 10_000L);
+        assertTrue(html, html.contains("host-b"));
+        assertTrue(html, html.contains("&mdash;"));      // ip / version / heap / uptime all missing
+        assertTrue(html, html.contains("badge bad"));
+        assertTrue(html, html.contains("disconnected"));
+    }
+
+    @Test
+    public void agentDetailsEscapesFields() {
+        AgentRegistry.AgentRecord record = new AgentRegistry.AgentRecord(
+                "<x>", "<ip>", 0, 0, AgentRegistry.Status.CONNECTED, "<v>", 1L, 2L);
+        String html = DashboardView.agentDetails(List.of(record), 0L);
+        assertTrue(html, html.contains("&lt;x&gt;"));
+        assertFalse(html, html.contains("<x>"));
+    }
+
+    @Test
+    public void agentDetailsEmptyShowsPlaceholder() {
+        assertTrue(DashboardView.agentDetails(new ArrayList<>(), 0L).contains("no agents"));
     }
 
     @Test


### PR DESCRIPTION
## Why

The dashboard only listed connected agent **ids**. Ops wanted a dedicated screen with per-agent details: name, IP, how long connected, JVM heap, agent version, and connected/disconnected status.

## What

A new **Agents** tab showing one row per agent. The data has two sources:

- **Server-derived** (no agent involvement): IP (from the WebSocket `remoteAddress()`), connect time / uptime, and status. A new `AgentRegistry` records `onConnect(agentId, ip)` / `onDisconnect(agentId)` and **retains disconnected agents** (with a last-seen time) so they still show up as `disconnected`.
- **Agent-reported**: the agent **pushes an `AgentInfo` message right after each connect** (fire-and-forget, not a round-trip) carrying its **version** and **JVM heap** (used/max). Agents reconnect ~every 60s, so the values refresh on their own. `AgentInfo` is a new `IAgentClientMessage` (`AGENT_INFO(6)`); the server's frame handler routes it into the registry.

Missing data renders as an empty cell.

### Agent version baking

The agent reports its own build version, **baked at build time from the git tag**:

- `agent-version.properties` (`version=${deploy.agent.version}`) is resource-filtered in `agent-websocket`.
- Parent pom default `deploy.agent.version = ${project.version}` → local builds show `1.0-SNAPSHOT`.
- `release.yml` passes `-Ddeploy.agent.version=${GITHUB_REF_NAME}`, so a released agent reports its release (e.g. `1.0-15`).
- `AgentVersion` reads the property from the classpath at startup.

### Dashboard

- `DashboardView.agentDetails(records, nowMs)` renders the table (same pattern as the Delivery table).
- `DashboardHttpHandler.pushSnapshot` streams it as a new `agentsDetail` SSE event, so uptime/status stay live.
- `index.html`: new **Agents** tab + section + `screens` JS entry.

## Tests

- `AgentRegistryTest`: connect → info → disconnect transitions, disconnected rows retained, reconnect, snapshot ordering (connected first).
- `DashboardViewTest`: `agentDetails` renders all fields, empty cells for missing data, both status badges, escaping.
- `mvn -B -ntp verify` green under JDK 21 (incl. the end-to-end integration test, where real agents now push `AgentInfo`). Verified the version filtering: default `1.0-SNAPSHOT`, `-Ddeploy.agent.version=1.0-15` → `1.0-15`.

## Deploy note

Protocol addition — **redeploy the agents to 1.0-15+** so they push `AgentInfo` and carry the baked version. Older agents simply show empty version/heap.