### PR TITLE
feat(diff): pick the new version by configured argument index (newVersionArg)

### DIFF
--- a/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
+++ b/client-redmine/src/main/java/io/pne/deploy/client/redmine/process/impl/DiffServiceImpl.java
@@ -85,7 +85,7 @@ public class DiffServiceImpl implements DiffService {
             return new ArrayList<>();
         }
         TaskDiff diff = task.diff;
-        String newVersion = taskVersion(task.taskLine);
+        String newVersion = taskVersion(task.taskLine, diff.getNewVersionArg());
         if (newVersion == null) {
             LOG.info("Diff: skip '{}' — no version in the task line", task.taskLine);
             return new ArrayList<>();
@@ -104,13 +104,24 @@ public class DiffServiceImpl implements DiffService {
         return diffTasks;
     }
 
-    /** The deploy version is the first parameter of the task line ("&lt;alias&gt; &lt;version&gt; ..."). */
-    private static String taskVersion(String taskLine) {
+    /**
+     * The new version is the {@code argIndex}-th task-line argument (1-based; {@code tokens[0]} is the alias name,
+     * so argument N is {@code tokens[N]}). {@code argIndex == 0} means the diff config has no {@code newVersionArg}.
+     */
+    private static String taskVersion(String taskLine, int argIndex) {
+        if (argIndex <= 0) {
+            LOG.error("Diff: skip '{}' — newVersionArg is not set (0)", taskLine);
+            return null;
+        }
         if (taskLine == null) {
             return null;
         }
         String[] tokens = taskLine.trim().split("\\s+");
-        return tokens.length >= 2 ? tokens[1] : null;
+        if (tokens.length <= argIndex) {
+            LOG.error("Diff: skip '{}' — no argument #{} in the task line", taskLine, argIndex);
+            return null;
+        }
+        return tokens[argIndex];
     }
 
     Map<DiffKey, DiffTask> aggregate(List<DiffTask> tasks) {

--- a/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
+++ b/client-redmine/src/test/java/io/pne/deploy/client/redmine/process/impl/DiffServiceProcessDiffTest.java
@@ -73,9 +73,10 @@ public class DiffServiceProcessDiffTest {
     }
 
     /**
-     * The diff is driven by {@code task.diff} (versionUrl / gitlabProjectId / agent), not by command arguments;
-     * newVersion is the first parameter of the task line. The old version is fetched through the agent
-     * (the deploy-server can't reach the firewalled versionUrl), so the reader is mocked here.
+     * The diff is driven by {@code task.diff} (versionUrl / gitlabProjectId / agent / newVersionArg), not by command
+     * arguments; newVersion is the task-line argument at index {@code diff.newVersionArg} (1 = the first argument).
+     * The old version is fetched through the agent (the deploy-server can't reach the firewalled versionUrl), so the
+     * reader is mocked here.
      */
     @Test
     public void getCurrentVersionUsesTaskDiff() {
@@ -83,7 +84,7 @@ public class DiffServiceProcessDiffTest {
         when(reader.readVersion("agent-1", versionUrl)).thenReturn("3.36.16-42");
 
         TaskDiff diff = TaskDiff.builder()
-                .enabled(true).versionUrl(versionUrl).gitlabProjectId(42).agent("agent-1").build();
+                .enabled(true).versionUrl(versionUrl).gitlabProjectId(42).agent("agent-1").newVersionArg(1).build();
         Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
                 Collections.emptyList(), "demo 3.36.16-100", 168059, diff);
 
@@ -107,5 +108,43 @@ public class DiffServiceProcessDiffTest {
                 Collections.emptyList(), "demo 1.2.3", 1,
                 TaskDiff.builder().enabled(false).versionUrl("http://x").gitlabProjectId(1).build());
         assertTrue(diffService.getCurrentVersion(disabled).isEmpty());
+    }
+
+    @Test
+    public void getCurrentVersionPicksTheConfiguredArgumentIndex() {
+        String versionUrl = "http://firewalled.example/version";
+        when(reader.readVersion("agent-1", versionUrl)).thenReturn("3.36.16-42");
+
+        TaskDiff diff = TaskDiff.builder()
+                .enabled(true).versionUrl(versionUrl).gitlabProjectId(42).agent("agent-1").newVersionArg(2).build();
+        Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "demo skip 3.36.16-100", 168059, diff);
+
+        List<DiffTask> diffTasks = diffService.getCurrentVersion(task);
+
+        assertEquals(1, diffTasks.size());
+        assertEquals("3.36.16-100", diffTasks.get(0).getNewVersion()); // 2nd argument, not the 1st ("skip")
+    }
+
+    @Test
+    public void getCurrentVersionWithoutNewVersionArgIsSkipped() {
+        TaskDiff diff = TaskDiff.builder() // newVersionArg defaults to 0
+                .enabled(true).versionUrl("http://x").gitlabProjectId(42).agent("agent-1").build();
+        Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "demo 3.36.16-100", 1, diff);
+
+        assertTrue(diffService.getCurrentVersion(task).isEmpty());
+        verifyNoInteractions(reader);
+    }
+
+    @Test
+    public void getCurrentVersionWithArgIndexOutOfRangeIsSkipped() {
+        TaskDiff diff = TaskDiff.builder()
+                .enabled(true).versionUrl("http://x").gitlabProjectId(42).agent("agent-1").newVersionArg(5).build();
+        Task task = new Task(TaskId.generateTaskId(), new TaskParameters(),
+                Collections.emptyList(), "demo 3.36.16-100", 1, diff); // only tokens[0..1]
+
+        assertTrue(diffService.getCurrentVersion(task).isEmpty());
+        verifyNoInteractions(reader);
     }
 }

--- a/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
+++ b/integration-test/src/test/java/io/pne/deploy/tests/env/LocalEnvironment.java
@@ -147,6 +147,7 @@ public class LocalEnvironment implements AutoCloseable {
                     + "  versionUrl: " + oldVersionUrl + "\n"
                     + "  gitlabProjectId: 42\n"
                     + "  agent: agent-1\n"
+                    + "  newVersionArg: 1\n"
                     + "commands:\n"
                     + "- agents: agent-1\n"
                     + "  name: echo\n"

--- a/server-api/src/main/java/io/pne/deploy/server/api/task/TaskDiff.java
+++ b/server-api/src/main/java/io/pne/deploy/server/api/task/TaskDiff.java
@@ -15,5 +15,6 @@ public class TaskDiff {
     String  versionUrl;
     int     gitlabProjectId;
     String  agent;
+    int     newVersionArg; // 1-based index of the task-line argument that carries the new version
 
 }

--- a/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasDiff.java
+++ b/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasDiff.java
@@ -6,4 +6,5 @@ public class AliasDiff {
     public String  versionUrl;
     public int     gitlabProjectId;
     public String  agent;
+    public int     newVersionArg; // 1-based index of the task-line argument that carries the new version
 }

--- a/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasParser.java
+++ b/server/src/main/java/io/pne/deploy/server/service/impl/alias/AliasParser.java
@@ -52,6 +52,7 @@ public class AliasParser {
                 .versionUrl(description.diff.versionUrl)
                 .gitlabProjectId(description.diff.gitlabProjectId)
                 .agent(description.diff.agent)
+                .newVersionArg(description.diff.newVersionArg)
                 .build();
         return new Task(TaskId.generateTaskId(), new TaskParameters(), commands, aText, aIssueId, diff);
     }


### PR DESCRIPTION
## Why

The diff logic derived the deployed (new) version by hardcoding the **first** task-line argument (`taskLine.split(...)[1]`). That is fragile whenever the version isn't the first argument after the alias.

## What

Add a `newVersionArg` field to the alias `diff:` block — a **1-based index** into the task-line arguments, matching the existing `$1`/`$2` placeholder convention (argument N = `tokens[N]`, since `tokens[0]` is the alias name). The diff now takes the new version from exactly that argument.

- `newVersionArg: 1` reproduces the previous behavior (first argument).
- If `newVersionArg` is **0 / unset** on an *enabled* diff, the server **logs an error** ("newVersionArg is not set") and **skips the diff** — no silent fallback.
- If the index is out of range for the task line, it logs and skips too.

Threaded through the existing diff-config chain: `AliasDiff` (YAML POJO) → `TaskDiff` (immutable `@Builder`) → `AliasParser.convertAliasDescriptionToTask` → `DiffServiceImpl.taskVersion(taskLine, argIndex)`.

## Tests

- `DiffServiceProcessDiffTest`: `newVersionArg(1)` (unchanged behavior), `newVersionArg(2)` picks the 2nd argument, `newVersionArg(0)` and an out-of-range index both skip (no reader interaction).
- The `integration-test` demo alias `diff:` block gets `newVersionArg: 1`.
- `mvn -B -ntp verify` green under JDK 21.

## Deploy note

Server-side only — **no protocol change, agents do not need redeploying**. Existing enabled `diff:` blocks in prod alias YAMLs must add `newVersionArg` (otherwise the diff is skipped with the logged error).