### PR TITLE
feat(agent): add execute bit to .sh scripts before running

### DIFF
--- a/agent/src/main/java/io/pne/deploy/agent/service/impl/AgentServiceImpl.java
+++ b/agent/src/main/java/io/pne/deploy/agent/service/impl/AgentServiceImpl.java
@@ -8,6 +8,7 @@ import io.pne.deploy.agent.service.log.IAgentLogService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ public class AgentServiceImpl implements IAgentService {
         Process process;
 
         try {
+            ensureExecutable(aCommand.command.name);
             process = new ProcessBuilder(createCommandWithArguments(aCommand.command)).start();
         } catch (IOException e) {
             throw new AgentCommandException("Can't start command", e);
@@ -75,5 +77,28 @@ public class AgentServiceImpl implements IAgentService {
         ret.add(aCommand.name);
         ret.addAll(aCommand.arguments);
         return ret;
+    }
+
+    /**
+     * Deploy often strips the execute bit off scripts. When argv[0] is a {@code .sh} file that exists but isn't
+     * executable, add the owner execute bit so the direct {@code exec} can launch it (the script still needs a shebang).
+     */
+    private void ensureExecutable(String aName) {
+        if (aName == null || !aName.endsWith(".sh")) {
+            return;
+        }
+        File file = new File(aName);
+        if (!file.isFile()) {
+            LOG.debug("Script {} not found as a file, running as-is", aName);
+            return;
+        }
+        if (file.canExecute()) {
+            return;
+        }
+        if (file.setExecutable(true)) {
+            LOG.info("Added execute bit to {}", aName);
+        } else {
+            LOG.warn("Could not add execute bit to {} (running anyway)", aName);
+        }
     }
 }

--- a/agent/src/test/java/io/pne/deploy/agent/service/impl/AgentServiceImplTest.java
+++ b/agent/src/test/java/io/pne/deploy/agent/service/impl/AgentServiceImplTest.java
@@ -1,0 +1,84 @@
+package io.pne.deploy.agent.service.impl;
+
+import io.pne.deploy.agent.api.command.AgentCommand;
+import io.pne.deploy.agent.api.command.AgentCommandParameters;
+import io.pne.deploy.agent.api.command.AgentCommandType;
+import io.pne.deploy.agent.api.exceptions.AgentCommandException;
+import io.pne.deploy.agent.api.messages.RunAgentCommandRequest;
+import io.pne.deploy.agent.service.log.IAgentLogService;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AgentServiceImplTest {
+
+    private final List<String>      output     = Collections.synchronizedList(new ArrayList<>());
+    private final IAgentLogService  logService = (id, text) -> output.add(text);
+    private final AgentServiceImpl  service    = new AgentServiceImpl(logService);
+
+    @Test
+    public void addsExecuteBitAndRunsShScriptWithoutIt() throws Exception {
+        File script = writeScript("#!/bin/sh\necho ok\n");
+        assertTrue(script.setExecutable(false));            // simulate the bit stripped by deploy
+        assertFalse("precondition: not executable", script.canExecute());
+
+        service.runCommand(request(script.getAbsolutePath())); // must not throw (exit 0)
+
+        assertTrue("execute bit added", script.canExecute());
+        assertTrue("script output captured", waitForOutput("ok"));
+    }
+
+    @Test
+    public void runsShScriptThatIsAlreadyExecutable() throws Exception {
+        File script = writeScript("#!/bin/sh\necho ok\n");
+        assertTrue(script.setExecutable(true));
+
+        service.runCommand(request(script.getAbsolutePath())); // must not throw
+
+        assertTrue(script.canExecute());
+        assertTrue(waitForOutput("ok"));
+    }
+
+    @Test
+    public void runsNonShCommandUnchanged() throws AgentCommandException, InterruptedException {
+        AgentCommand echo = new AgentCommand(new AgentCommandParameters(), AgentCommandType.SHELL,
+                "echo", Collections.singletonList("hello"));
+        service.runCommand(new RunAgentCommandRequest("agent-1", "cmd-1", echo)); // must not throw
+        assertTrue(waitForOutput("hello"));
+    }
+
+    private File writeScript(String content) throws Exception {
+        File script = File.createTempFile("agent-service-test", ".sh");
+        script.deleteOnExit();
+        Files.writeString(script.toPath(), content, StandardCharsets.UTF_8);
+        return script;
+    }
+
+    private static RunAgentCommandRequest request(String name) {
+        AgentCommand command = new AgentCommand(new AgentCommandParameters(), AgentCommandType.SHELL,
+                name, Collections.emptyList());
+        return new RunAgentCommandRequest("agent-1", "cmd-1", command);
+    }
+
+    private boolean waitForOutput(String expected) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            synchronized (output) {
+                for (String line : output) {
+                    if (line.contains(expected)) {
+                        return true;
+                    }
+                }
+            }
+            Thread.sleep(40);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Why

The deploy-agent runs every command with `new ProcessBuilder([name, args...]).start()` — a direct OS exec, no shell. When a deployed `.sh` loses its execute bit during deploy, `start()` fails with `IOException` ("Permission denied"), surfaced as `AgentCommandException("Can't start command")`.

## What

Before launching, if `argv[0]` (`command.name`) ends with `.sh`, locate the file and — if it exists and isn't executable — add the owner execute bit (`File.setExecutable(true)`), then run exactly as before. Idempotent (only touches files whose bit is missing); non-`.sh` commands and bare `PATH` names are untouched. Agent hosts are mounted read-write, so the chmod won't hit a read-only FS.

`AgentServiceImpl.ensureExecutable(name)` is called right before `ProcessBuilder.start()`; everything else (argv building, direct exec, output streaming, exit handling) is unchanged.

## Tests

New `AgentServiceImplTest` (the agent module's first test):
- a `.sh` with a shebang but no execute bit runs successfully and the bit is added afterwards;
- an already-executable `.sh` still runs;
- a non-`.sh` command (`echo`) runs unchanged.

`mvn -B -ntp verify` green under JDK 21.

## Notes

- The script must still start with a shebang (e.g. `#!/bin/bash`) — direct exec needs it (no `/bin/sh` fallback); the execute bit alone isn't enough.
- Agent-side only, **no protocol change**, but **redeploy the agents** to get the new behavior.